### PR TITLE
Issue #79 Removing exception from interface method.

### DIFF
--- a/api/src/main/java/com/stormpath/sdk/oauth/AccessTokenRequestAuthenticator.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/AccessTokenRequestAuthenticator.java
@@ -90,5 +90,5 @@ public interface AccessTokenRequestAuthenticator {
      *
      * @return the result of the authentication request in the form of a {@link AccessTokenResult}.
      */
-    public AccessTokenResult execute() throws Exception;
+    public AccessTokenResult execute();
 }


### PR DESCRIPTION
While using the api authentication methods, realized that the AccessTokenRequestAuthenticator.execute() method throws an unnecessary exception, making all clients that use this method to wrap it by a try/catch clause or propagate it. The default implementation of this interface doesn't even throw the exception.
