### PR TITLE
Added STORMPATH_BASE_URL for people testing against local configs

### DIFF
--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/client/ClientIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/client/ClientIT.groovy
@@ -35,7 +35,7 @@ abstract class ClientIT {
 
     private static final Logger log = LoggerFactory.getLogger(ClientIT)
 
-    String baseUrl = 'https://api.stormpath.com/v1'
+    String baseUrl = System.getenv("STORMPATH_BASE_URL") ?: 'https://api.stormpath.com/v1'
     Client client
 
     List<Deletable> resourcesToDelete;


### PR DESCRIPTION
As a Stormpath employee, if you are running a local instance of Stormpath, having the STORMPATH_BASE_URL set alleviates the need to edit ClientIT just for running tests.

You can execute the fill integration test suite as:

```
STORMPATH_API_KEY_ID=<api key id> \
STORMPATH_API_KEY_SECRET=<api key secret> \
STORMPATH_BASE_URL=http://localhost:9191/v1 \
mvn clean install -DskipITs=false
```