### PR TITLE
323 refactor secure by default behavior

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 ## Change Log ##
 
+### 1.0.RC5.1 ##
+
+Notes:
+
+- Please see the [1.0.RC5.1](https://github.com/stormpath/stormpath-sdk-java/issues?q=milestone%3A1.0.RC5.1+is%3Aclosed) issues list for more information
+
 ### 1.0.RC5 ##
 
 Notes:

--- a/extensions/spring/boot/docs/source/quickstart.rst
+++ b/extensions/spring/boot/docs/source/quickstart.rst
@@ -37,20 +37,12 @@ Did you experience any problems with this quickstart?  It might not have worked 
 
       stormpath.application.href = https://api.stormpath.com/v1/applications/YOUR_APPLICATION_ID
 
-* you don't want to use Spring Security or you are already using it and there are conflicts. You can easily disable Stormpath Spring Boot Spring Security by excluding the Stormpath security auto-configuration in your ``Application.java`` like so:
+* you don't want to use Spring Security or you are already using it and there are conflicts. You can easily disable Spring Security by adding two properties to ``application.properties``:
 
-  .. code-block:: java
-     :emphasize-lines: 2
+  .. code-block:: properties
 
-      @SpringBootApplication
-      @EnableAutoConfiguration(exclude = { StormpathWebSecurityAutoConfiguration.class })
-      public class Application  {
-
-          public static void main(String[] args) {
-              SpringApplication.run(Application.class, args);
-          }
-
-      }
+     stormpath.spring.security.enabled = false
+     security.basic.enabled = false
 
 * your web app already uses web frameworks that make heavy use of servlet filters, like Spring Security or Apache Shiro. These could cause filter ordering conflicts, but the fix is easy - you just need to specify the specific order where you want the Stormpath filter relative to other filters.  You do this by adding the following to your Spring Boot ``application.properties`` file (where ``preferred_value`` is your preferred integer value):
 

--- a/extensions/spring/boot/docs/source/stormpath-spring-boot-setup.txt
+++ b/extensions/spring/boot/docs/source/stormpath-spring-boot-setup.txt
@@ -67,15 +67,10 @@ In order to connect Stormpath and Spring Security, we need one small configurati
     @Configuration
     public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAdapter {}
 
-Without this, you will get a popup in your browser prompting for authentication, which is the default behavior for Spring Security.
+Without this, you will get a popup in your browser prompting for authentication, which is the default basic authentication for Spring Security.
 
 Also, by default, all paths are locked down with Spring Security. Stormpath's Spring Security integration follows this idiomatic
-behavior. If you instead would like to enable access to all paths in your quickstart application, simply add the following line
-to your ``application.properties`` file:
-
-.. code-block:: properties
-
-   stormpath.spring.security.fullyAuthenticated.enabled = false
+behavior.
 
 That's it!  You're ready to start using Stormpath in your Spring Boot web application!  Can you believe how easy that was?
 

--- a/extensions/spring/boot/docs/source/tutorial.rst
+++ b/extensions/spring/boot/docs/source/tutorial.rst
@@ -5,15 +5,16 @@ Tutorial
 
 This tutorial will take you from zero to a Stormpath enabled application featuring Spring Boot WebMVC and Spring Security integration.
 
-It should take about 30 minutes from start to finish. If you are looking for a barebones intro to using Stormpath and
+It should take about 30 minutes from start to finish. If you are looking for a bare bones intro to using Stormpath and
 Spring Boot, check out the :doc:`quickstart`.
 
 If you've already gone through the quickstart, jump over to the :ref:`spring-boot-meet-stormpath` section.
 
-If you are already familiar with Spring Boot and Spring Security, jump right to the :ref:`spring-security-refined` section
-to see how nicely Stormpath integrates with Spring Security.
-
 We will be referring to the tutorial code found `here <https://github.com/stormpath/stormpath-sdk-java/tree/master/tutorials/spring-boot>`_.
+
+All of the code in the tutorial makes use of the ``stormpath-default-spring-boot-starter``. This starter has it all:
+Spring WebMvc, Spring Security and the Thymeleaf templating engine - all integrated with Stormpath. Component features,
+such as Spring Security, can easily be disabled through the use of properties or via annotations.
 
 Topics:
 
@@ -47,10 +48,6 @@ For a gradle build and run, do this:
     java -jar build/libs/00-the-basics-0.1.0.jar
 
 You should now be able to browse to `<http://localhost:8080>`_ and see a welcome message with your Stormpath application's name.
-
-The Stormpath library used for this example is: ``stormpath-webmvc-spring-boot-starter``. This provides basic integration with
-Stormpath and Spring Boot WebMVC apps. It does NOT include the Stormpath Thymeleaf views or the Stormpath Spring Security
-integration. Stay tuned for more on those integrations when we look at the ``stormpath-default-spring-boot-starter``.
 
 This application has just two code files in it. Here's the structure:
 
@@ -100,6 +97,11 @@ line 6 we are obtaining its name for display.
 Pretty simple setup, right? In the next section, we'll layer in some flow logic based on logged-in state. And then we
 will refine that to make use of all the Spring Security has to offer in making our lives easier.
 
+Feeling adventurous? Browse on over to ``http://localhost:8080/login``. You will see the default Stormpath login form.
+You can login in as an existing user, register a new user and even reset your password. Where did this come from? It's
+all part of the built in authentication flows that Stormpath provides. With a 1-line ``main`` method and
+a 2-line controller, you get all this functionality out of the box.
+
 .. _some-access-controls:
 
 Some Access Controls
@@ -111,12 +113,6 @@ In the next section, we will talk about having access controls the "right" way b
 
 The purpose of this section is to demonstrate the manual labor required in "rolling your own" permissions assertion layer.
 Feel free to skip right over to the :ref:`spring-security-meet-stormpath` section.
-
-The Stormpath libraries used for this example are: ``stormpath-webmvc-spring-boot-starter`` and
-``stormpath-thymeleaf-spring-boot-starter``. This provides basic integration with Stormpath and Spring Boot WebMVC apps.
-Additionally, it provides a default set of thymeleaf views for common auth workflows, such as ``/login``, ``/register`` and
-``/forgot`` (for dealing with forgotten passwords). It does NOT (yet) include Stormpath Spring Security integration. In the next
-section, we will jump into the Stormpath Spring Security integration.
 
 The code for this section can be found `here <https://github.com/stormpath/stormpath-sdk-java/tree/master/tutorials/spring-boot/01-some-access-controls>`_.
 
@@ -151,8 +147,6 @@ Let's take a look at the updated ``HelloController.java`` file:
 
 If we are able to get an account via ``AccountResolver.INSTANCE.getAccount(req)``, then we return the ``restricted``
 template. Otherwise, we redirect to ``/login``.
-
-Build and run the application as before and try it out!
 
 The code from this section also incorporates some other cool features of
 `stormpath-default-spring-boot-starter <https://github.com/stormpath/stormpath-sdk-java/tree/master/extensions/spring/boot/stormpath-default-spring-boot-starter>`_.
@@ -190,10 +184,6 @@ The official Spring Security documentation is `here <http://projects.spring.io/s
 Let's take a look at the additions and changes to the project.
 The code for this section can be found `here <https://github.com/stormpath/stormpath-sdk-java/tree/master/tutorials/spring-boot/02-spring-security-ftw>`_.
 
-The only Stormpath library used for this example (and those that follow) is: ``stormpath-default-spring-boot-starter``. This is the
-library that we expect you will most often use. It includes the Stormpath Spring Boot, Spring Boot WebMVC, Spring Boot Spring Security, and
-Spring Boot Thymeleaf template engine integrations.
-
 We've added a configuration file called ``SpringSecurityWebAppConfig.java``. How does Spring know it's a configuration file?
 It has the ``@Configuration`` annotation:
 
@@ -206,19 +196,20 @@ It has the ``@Configuration`` annotation:
         protected void doConfigure(HttpSecurity http) throws Exception {
             http
                 .authorizeRequests()
-                .antMatchers("/**").permitAll();
+                .antMatchers("/").permitAll();
         }
     }
 
 Why have this configuration? Spring Security expects things to be, well - secured. If there is not a class that extends
 ``WebSecurityConfigurerAdapter`` in the application, Spring Security will protect *every* pathway and will provide a default
-basic authentication popup in your browser. In order to properly hook into the Stormpath Spring Security integration, you
-need to extend ``StormpathWebSecurityConfigurerAdapter`` which itself extends ``WebSecurityConfigurerAdapter``. NOTE: Please
+basic authentication popup to your browser. In order to easily hook into the Stormpath Spring Security integration, you
+can extend ``StormpathWebSecurityConfigurerAdapter`` which itself extends ``WebSecurityConfigurerAdapter``. NOTE: Please
 refer to the :ref:`advanced-spring-security-integration` section for how to configure your app *without* extending
 ``StormpathWebSecurityConfigurerAdapter``.
 
-Based on the ``SpringSecurityWebAppConfig`` above, we will permit access to all paths. We are going to protect access to a
-service by requiring group membership with the ``@PreAuthorize`` annotation (as you'll see below).
+Based on the ``SpringSecurityWebAppConfig`` above, we will permit access to the homepage. Any other paths will fall back
+to the default of being secured - you would be redirected to the Stormpath login page. We are going to further protect
+access to a service by requiring group membership with the ``@PreAuthorize`` annotation (as you'll see below).
 
 Next, we've added a service called ``HelloService.java``:
 
@@ -348,7 +339,7 @@ the application.
 
 By default, Spring will name the bean in context using camelcase conventions. Therefore the bean will be named ``roles``.
 
-We use some Spring magic on lines 5 and 6 to pass the ``Environment`` into the constructor.
+We use some Spring magic on lines 5 and 6 to pass the ``Environment`` into the constructor using the `@Autowired` annotation.
 
 In the constructor, we set the ``USER`` variable to the value of the environment property called ``stormpath.authorized.group.user``.
 
@@ -358,7 +349,7 @@ Stormpath group that backs the ``USER`` role.
 With Spring, you can define the ``stormpath.authorized.group.user`` in the ``application.properties`` file and that property will be available
 to your app.
 
-Now for the Stormpath magic. You can also have a system environment variable named ``STORMPATH_AUTHORIZED_GROUP_USER``.
+Now, for the Stormpath magic. You can also have a system environment variable named ``STORMPATH_AUTHORIZED_GROUP_USER``.
 Behind the scenes, Stormpath will convert that system environment variable to a Spring environment variable named
 ``stormpath.authorized.group.user``.
 
@@ -395,37 +386,7 @@ You can try this out for yourself by running this example like so:
 
 In this example, we are also taking advantage of Stormpath's configuration mechanism. This reduces boilerplate code.
 
-If you take a look at our ``SpringSecurityWebAppConfig``, you'll see that it's empty:
-
-.. code-block:: java
-
-    @Configuration
-    public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAdapter {}
-
-We said earlier, that by default all paths would be protected, as is the Spring Security way. So, what's different here?
-
-If you look at the ``application.properties`` file, you will see:
-
-.. code-block:: properties
-
-   stormpath.spring.security.fullyAuthenticated.enabled = false
-
-This line disables the default behavior of protecting all paths. Without this line, our ``SpringSecurityWebAppConfig`` would
-need to look like it did in previous examples, if we did want to make it so that all paths are permitted:
-
-.. code-block:: java
-
-    @Configuration
-    public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAdapter {
-        @Override
-        protected void doConfigure(HttpSecurity http) throws Exception {
-            http
-                .authorizeRequests()
-                .antMatchers("/**").permitAll();
-        }
-    }
-
-The one line of configuration in ``application.properties`` saved us six lines of boilerplate java code.
+Next up: An even finer grain of control using Spring Security permissions.
 
 .. _a-finer-grain-of-control:
 
@@ -434,43 +395,30 @@ A Finer Grain of Control
 
 The code for this section can be found `here <https://github.com/stormpath/stormpath-sdk-java/tree/master/tutorials/spring-boot/04-a-finer-grain-of-control>`_.
 
-So far, everything we've done with Spring Security has been through the `@PreAuthorize` annotation. In this section, we are going to look at examples
-that give a finer grain of control and demonstrate how Stormpath hooks into Spring Security.
+So far, we've restricted access to certain methods with the `hasRole` clause of the `@PreAuthorize` annotation. In this
+section, we are going to look at examples that give a finer grain of control and demonstrate how Stormpath hooks into
+Spring Security.
 
-As documented by the Spring team, it's common to have a ``WebSecurityConfigurerAdapter`` and to use a fluent interface to build security rules.
-
-Stormpath hooks into that architecture to enable you to build security rules while protecting access to the built-in Stormpath authentication flows.
-
-Let's take a look at the new file in the example, ``SpringSecurityWebAppConfig``:
+We're using the same ``SpringSecurityWebAppConfig`` that we've had in the previous examples:
 
 .. code-block:: java
     :linenos:
-    :emphasize-lines: 2,4
 
     @Configuration
     public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAdapter {
-
         @Override
         protected void doConfigure(HttpSecurity http) throws Exception {
             http
                 .authorizeRequests()
-                .antMatchers("/me").fullyAuthenticated()
-                .antMatchers("/**").permitAll();
+                .antMatchers("/").permitAll();
         }
-
     }
 
-Notice on line 2, we are extending ``StormpathWebSecurityConfigurerAdapter`` which itself extends ``WebSecurityConfigurerAdapter``.
-
-The ``configure`` method of ``StormpathWebSecurityConfigurerAdapter`` does some housekeeping to ensure that all of the Stormpath
-views (such as /login) remain available and then it calls your ``doConfigure`` method.
-
-In this case, we are expressing that anyone trying to get to ``/me`` should be fully authenticated. And, we are saying that
-access to any other path will be permitted.
+This allows unauthenticated access to the homepage ``/``.
 
 For more on ``HttpSecurity`` with Spring Security, look `here <http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#jc-httpsecurity>`_.
 
-The new method to handle ``me`` requests in our ``HelloController`` does not call out any other authorizaton requirements. Anyone logged in will be able to
+We've added a new method to our ``HelloController``. It does not call out any other authorizaton requirements. Anyone logged in will be able to
 access ``/me``. Furthermore, anyone NOT logged in trying to access ``/me`` will automatically be redirected to the ``/login`` view.
 
 .. code-block:: java
@@ -641,5 +589,6 @@ applications.
 You can use the Stormpath Spring Security integration in contexts other than Spring Boot as well. For instance, you could
 write a REST API that makes use of Spring Security that has no web layer.
 
-Take a look at the `javadocs </java/apidocs>`_ for a more in depth look at Spring Security as well as the other
-code examples `here <https://github.com/stormpath/stormpath-sdk-java/tree/master/examples>`_.
+Take a look at the `javadocs </java/apidocs>`_ as well as the other code examples
+`here <https://github.com/stormpath/stormpath-sdk-java/tree/master/examples>`_ for more information on all that the
+Stormpath Java SDK has to offer.

--- a/extensions/spring/boot/docs/source/tutorial.rst
+++ b/extensions/spring/boot/docs/source/tutorial.rst
@@ -13,8 +13,9 @@ If you've already gone through the quickstart, jump over to the :ref:`spring-boo
 We will be referring to the tutorial code found `here <https://github.com/stormpath/stormpath-sdk-java/tree/master/tutorials/spring-boot>`_.
 
 All of the code in the tutorial makes use of the ``stormpath-default-spring-boot-starter``. This starter has it all:
-Spring WebMvc, Spring Security and the Thymeleaf templating engine - all integrated with Stormpath. Component features,
-such as Spring Security, can easily be disabled through the use of properties or via annotations.
+Spring Boot, Spring Web MVC, Spring Security and the Thymeleaf templating engine - all integrated with Stormpath. Component features,
+such as Spring Security, can easily be disabled through the use of properties or via annotations. (You'll see an example of disabling
+Spring Security with properties in the :ref:`spring-boot-meet-stormpath` section).
 
 Topics:
 
@@ -286,7 +287,7 @@ Spring Security Refined
 
 The code for this section can be found `here <https://github.com/stormpath/stormpath-sdk-java/tree/master/tutorials/spring-boot/03-spring-security-refined>`_.
 
-In the previouse section, we hard-coded the Stormpath group href into ``HelloService``.
+In the previous section, we hard-coded the Stormpath group href into ``HelloService``.
 
 This is cumbersome in a real world situation where you may have multiple environments (dev, stage, prod, etc.).
 You don't want to have to change source, recompile and deploy for a new environment or when you change a group in Stormpath.
@@ -399,27 +400,13 @@ So far, we've restricted access to certain methods with the `hasRole` clause of 
 section, we are going to look at examples that give a finer grain of control and demonstrate how Stormpath hooks into
 Spring Security.
 
-We're using the same ``SpringSecurityWebAppConfig`` that we've had in the previous examples:
-
-.. code-block:: java
-    :linenos:
-
-    @Configuration
-    public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAdapter {
-        @Override
-        protected void doConfigure(HttpSecurity http) throws Exception {
-            http
-                .authorizeRequests()
-                .antMatchers("/").permitAll();
-        }
-    }
-
-This allows unauthenticated access to the homepage ``/``.
+As before, we allow unauthenticated access to the homepage ``/`` in ``SpringSecurityWebAppConfig.java``.
 
 For more on ``HttpSecurity`` with Spring Security, look `here <http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#jc-httpsecurity>`_.
 
-We've added a new method to our ``HelloController``. It does not call out any other authorizaton requirements. Anyone logged in will be able to
-access ``/me``. Furthermore, anyone NOT logged in trying to access ``/me`` will automatically be redirected to the ``/login`` view.
+We've added a new method to our ``HelloController``. It does not call out any other authorizaton requirements. As such,
+anyone logged in will be able to access ``/me``. Furthermore, anyone NOT logged in trying to access ``/me`` will automatically
+be redirected to the ``/login`` view.
 
 .. code-block:: java
     :linenos:
@@ -440,7 +427,7 @@ access ``/me``. Furthermore, anyone NOT logged in trying to access ``/me`` will 
 Try it out. Launch the application as before, and then browse to: ``http://localhost:8080/me``. You will be redirected to the ``/login``
 and then after you login to a valid Stormpath Account, you will automatically be brought back to ``/me``. That's the StormPath magic at work!
 
-The last thing we'll look at here is fine grained controls using Spring Security permissions connected to Stormpath custom data.
+Now, we'll look at fine grained controls using Spring Security permissions connected to Stormpath custom data.
 
 Every first class object in Stormpath can have custom data associated with it. For instance, you can have custom data at the Group level as well
 as at the Account level.
@@ -515,8 +502,12 @@ Advanced Spring Security Integration
 There are times when you will want to hook into the Stormpath Spring Security Integration at a deeper level. Or, perhaps you
 have a scenario where you are already extending a class from another library and do not have the option of extending ``StormpathWebSecurityConfigurerAdapter``.
 
-In these situations, your ``@Configuration`` class can interact with the ``StormpathWebSecurityConfigurer`` directly. Take a
-look what this looks like:
+In these situations, your ``@Configuration`` class can interact with the ``StormpathWebSecurityConfigurer`` directly.
+
+Let's say that we want to set it up so that only authenticated users can get to ``/restrcited`` and that unauthenticated users can get anywhere
+else in our application.
+
+Take a look what this looks like when not extending ``StormpathWebSecurityConfigurer``:
 
 .. code-block:: java
     :linenos:

--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebSecurityConfigurer.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebSecurityConfigurer.java
@@ -67,9 +67,6 @@ public class StormpathWebSecurityConfigurer {
     @Value("#{ @environment['stormpath.spring.security.enabled'] ?: true }")
     protected boolean stormpathSecuritybEnabled;
 
-    @Value("#{ @environment['stormpath.spring.security.fullyAuthenticated.enabled'] ?: true }")
-    protected boolean fullyAuthenticatedEnabled;
-
     @Value("#{ @environment['stormpath.web.enabled'] ?: true }")
     protected boolean stormpathWebEnabled;
 
@@ -169,11 +166,6 @@ public class StormpathWebSecurityConfigurer {
             }
             if (verifyEnabled) {
                 http.authorizeRequests().antMatchers(verifyUri).permitAll();
-            }
-            if (fullyAuthenticatedEnabled) {
-                http
-                    .authorizeRequests()
-                    .antMatchers("/**").fullyAuthenticated();
             }
         }
     }

--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebSecurityConfigurerAdapter.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebSecurityConfigurerAdapter.java
@@ -16,6 +16,7 @@
 package com.stormpath.spring.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -32,6 +33,9 @@ public class StormpathWebSecurityConfigurerAdapter extends WebSecurityConfigurer
 
     @Autowired
     protected StormpathWebSecurityConfigurer stormpathWebSecurityConfigurer;
+
+    @Value("#{ @environment['stormpath.spring.security.fullyAuthenticated.enabled'] ?: true }")
+    protected boolean fullyAuthenticatedEnabled;
 
     /**
      * The pre-defined Stormpath access control settings are defined here.
@@ -50,6 +54,11 @@ public class StormpathWebSecurityConfigurerAdapter extends WebSecurityConfigurer
     protected final void configure(HttpSecurity http) throws Exception {
         stormpathWebSecurityConfigurer.configure(http);
         doConfigure(http);
+        if (fullyAuthenticatedEnabled) {
+            http
+                .authorizeRequests()
+                .antMatchers("/**").fullyAuthenticated();
+        }
     }
 
     /**

--- a/tutorials/spring-boot/00-the-basics/pom.xml
+++ b/tutorials/spring-boot/00-the-basics/pom.xml
@@ -33,7 +33,7 @@
         <!-- Compile-time dependencies: -->
         <dependency>
             <groupId>com.stormpath.spring</groupId>
-            <artifactId>stormpath-webmvc-spring-boot-starter</artifactId>
+            <artifactId>stormpath-default-spring-boot-starter</artifactId>
         </dependency>
 
         <!-- Runtime-only dependencies: -->

--- a/tutorials/spring-boot/00-the-basics/src/main/resources/application.properties
+++ b/tutorials/spring-boot/00-the-basics/src/main/resources/application.properties
@@ -18,3 +18,6 @@
 # corresponds to this webapp:
 #
 #stormpath.application.href = https://api.stormpath.com/v1/applications/YOUR_APPLICATION_ID_HERE
+
+stormpath.spring.security.enabled = false
+security.basic.enabled = false

--- a/tutorials/spring-boot/01-some-access-controls/pom.xml
+++ b/tutorials/spring-boot/01-some-access-controls/pom.xml
@@ -33,14 +33,10 @@
         <!-- Compile-time dependencies: -->
         <dependency>
             <groupId>com.stormpath.spring</groupId>
-            <artifactId>stormpath-webmvc-spring-boot-starter</artifactId>
+            <artifactId>stormpath-default-spring-boot-starter</artifactId>
         </dependency>
 
         <!-- Runtime-only dependencies: -->
-        <dependency>
-            <groupId>com.stormpath.spring</groupId>
-            <artifactId>stormpath-thymeleaf-spring-boot-starter</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>

--- a/tutorials/spring-boot/01-some-access-controls/src/main/resources/application.properties
+++ b/tutorials/spring-boot/01-some-access-controls/src/main/resources/application.properties
@@ -19,4 +19,7 @@
 #
 #stormpath.application.href = https://api.stormpath.com/v1/applications/YOUR_APPLICATION_ID_HERE
 
+stormpath.spring.security.enabled = false
+security.basic.enabled = false
+
 stormpath.web.logout.nextUri = /?status=logout

--- a/tutorials/spring-boot/02-spring-security-ftw/src/main/java/com/stormpath/tutorial/config/SpringSecurityWebAppConfig.java
+++ b/tutorials/spring-boot/02-spring-security-ftw/src/main/java/com/stormpath/tutorial/config/SpringSecurityWebAppConfig.java
@@ -28,6 +28,6 @@ public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAd
     protected void doConfigure(HttpSecurity http) throws Exception {
         http
             .authorizeRequests()
-            .antMatchers("/**").permitAll();
+            .antMatchers("/").permitAll();
     }
 }

--- a/tutorials/spring-boot/03-spring-security-refined/src/main/java/com/stormpath/tutorial/config/SpringSecurityWebAppConfig.java
+++ b/tutorials/spring-boot/03-spring-security-refined/src/main/java/com/stormpath/tutorial/config/SpringSecurityWebAppConfig.java
@@ -17,9 +17,17 @@ package com.stormpath.tutorial.config;
 
 import com.stormpath.spring.config.StormpathWebSecurityConfigurerAdapter;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 
 /**
  * @since 1.0.RC5
  */
 @Configuration
-public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAdapter {}
+public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAdapter {
+    @Override
+    protected void doConfigure(HttpSecurity http) throws Exception {
+        http
+            .authorizeRequests()
+            .antMatchers("/").permitAll();
+    }
+}

--- a/tutorials/spring-boot/03-spring-security-refined/src/main/resources/application.properties
+++ b/tutorials/spring-boot/03-spring-security-refined/src/main/resources/application.properties
@@ -19,5 +19,3 @@
 #
 #stormpath.application.href = https://api.stormpath.com/v1/applications/YOUR_APPLICATION_ID_HERE
 #stormpath.authorized.group.user = https://api.stormpath.com/v1/groups/YOUR_GROUP_ID_HERE
-
-stormpath.spring.security.fullyAuthenticated.enabled = false

--- a/tutorials/spring-boot/04-a-finer-grain-of-control/src/main/java/com/stormpath/tutorial/config/Roles.java
+++ b/tutorials/spring-boot/04-a-finer-grain-of-control/src/main/java/com/stormpath/tutorial/config/Roles.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 /**
  * @since 1.0.RC5
  */
-@Component("Roles")
+@Component
 public class Roles {
     public final String USER;
 

--- a/tutorials/spring-boot/04-a-finer-grain-of-control/src/main/java/com/stormpath/tutorial/config/SpringSecurityWebAppConfig.java
+++ b/tutorials/spring-boot/04-a-finer-grain-of-control/src/main/java/com/stormpath/tutorial/config/SpringSecurityWebAppConfig.java
@@ -29,8 +29,7 @@ public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAd
     protected void doConfigure(HttpSecurity http) throws Exception {
         http
             .authorizeRequests()
-            .antMatchers("/me").fullyAuthenticated()
-            .antMatchers("/**").permitAll();
+            .antMatchers("/").permitAll();
     }
 
 }

--- a/tutorials/spring-boot/04-a-finer-grain-of-control/src/main/java/com/stormpath/tutorial/service/HelloService.java
+++ b/tutorials/spring-boot/04-a-finer-grain-of-control/src/main/java/com/stormpath/tutorial/service/HelloService.java
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class HelloService {
-    @PreAuthorize("hasRole(@Roles.USER) and hasPermission('say', 'hello')")
+    @PreAuthorize("hasRole(@roles.USER) and hasPermission('say', 'hello')")
     public String sayHello(Account account) {
         return "Hello, " + account.getGivenName() +
             ". You have the required permissions to access this restricted resource.";


### PR DESCRIPTION
- moves `fullyAuthenticatedEnable` check into `StormpathWebSecurityConfigurerAdapter` and out of `StormpathWebSecurityConfigurer` to ensure that user security preferences take precedence.

- updates tutorial code to make use of `stormpath-default-spring-boot-starter` throughout

- updates tutorial documentation to match tutorial code changes

addresses #322 