### PR TITLE
Refactored DefaultPropertiesParser

### DIFF
--- a/impl/src/main/java/com/stormpath/sdk/impl/config/DefaultPropertiesParser.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/config/DefaultPropertiesParser.java
@@ -151,8 +151,8 @@ public class DefaultPropertiesParser implements PropertiesParser {
         String key = Strings.clean(keyBuffer.toString());
         String value = Strings.clean(valueBuffer.toString());
 
-        if (key == null || value == null) {
-            String msg = "Line argument must contain a key and a value.  Only one string token was found.";
+        if (key == null) {
+            String msg = "Line argument must contain a key. None was found.";
             throw new IllegalArgumentException(msg);
         }
 

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/config/DefaultPropertiesParserTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/config/DefaultPropertiesParserTest.groovy
@@ -1,0 +1,68 @@
+package com.stormpath.sdk.impl.config
+
+import com.stormpath.sdk.impl.io.Resource
+import org.testng.annotations.BeforeTest
+import org.testng.annotations.Test
+import static org.testng.Assert.assertEquals
+import static org.testng.Assert.fail
+
+class DefaultPropertiesParserTest {
+    def parser
+
+    @BeforeTest
+    void setup() {
+        parser = new DefaultPropertiesParser()
+    }
+
+    @Test
+    void testKeyValueNoWhitespace() {
+        def resource = new StringResource("stormpath.web.verify.nextUri=/login?status=verified")
+        def result = parser.parse(resource)
+
+        assertEquals(result.size(), 1)
+        assertEquals(result.get("stormpath.web.verify.nextUri"), "/login?status=verified")
+    }
+
+    @Test
+    void testKeyValueLotsOfWhitespace() {
+        def resource = new StringResource("stormpath.web.verify.nextUri                                                     =                                         /login?status=verified")
+        def result = parser.parse(resource)
+
+        assertEquals(result.size(), 1)
+        assertEquals(result.get("stormpath.web.verify.nextUri"), "/login?status=verified")
+    }
+
+    @Test
+    void testKeyNoValue() {
+        def resource = new StringResource("stormpath.web.verify.nextUri = ")
+        def result = parser.parse(resource)
+
+        assertEquals(result.size(), 1)
+        assertEquals(result.get("stormpath.web.verify.nextUri"), null)
+    }
+
+    @Test
+    void testValueNoKey() {
+        def resource = new StringResource(" = /login?status=verified")
+
+        try {
+            parser.parse(resource)
+            fail()
+        } catch (IllegalArgumentException iae) {
+            assertEquals(iae.message, "Line argument must contain a key. None was found.")
+        }
+    }
+}
+
+class StringResource implements Resource {
+    private String string
+
+    StringResource(String string) {
+        this.string = string
+    }
+
+    @Override
+    InputStream getInputStream() throws IOException {
+        new ByteArrayInputStream(string.bytes)
+    }
+}


### PR DESCRIPTION
Refactored to allow empty properties. Added test for `DefaultPropertiesParser`.

Current `default.stormpath.properties` has empty keys in it which is causing `DefaultPropertiesParser` to blow up in servlet.

addresses #328 