### PR TITLE
updated tutorial and quickstart per @lhazlewood's feedback. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
     -d
   - chmod 600 ~/.ssh/id_rsa
   - export RELEASE_VERSION="$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)')"
-  - export IS_RELEASE="$([ ${RELEASE_VERSION/SNAPSHOT} == $RELEASE_VERSION ] && echo 'true')"
+  - export IS_RELEASE="$([ ${RELEASE_VERSION/SNAPSHOT} == $RELEASE_VERSION ] && [ $TRAVIS_BRANCH == 'master' ] && echo 'true')"
   - export BUILD_DOCS="$([ $TRAVIS_JDK_VERSION == 'oraclejdk8' ] && echo 'true')"
 install: 
   - test -z "$BUILD_DOCS" || pip install --user sphinx

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -12,4 +12,4 @@ make html
 cd ../../../../
 
 # javadocs
-mvn javadoc:aggregate -P docs
+mvn javadoc:aggregate -P travis-docs

--- a/extensions/spring/boot/docs/source/quickstart.rst
+++ b/extensions/spring/boot/docs/source/quickstart.rst
@@ -13,6 +13,50 @@ Topics:
 
 .. include:: stormpath-spring-boot-setup.txt
 
+.. _dependency-jar:
+
+Add the Stormpath Default Spring Boot Starter
+---------------------------------------------
+
+This step allows you to enable Stormpath in a Spring Boot web app with *very minimal* configuration.
+It includes Stormpath Spring Security, Stormpath Spring WebMVC and Stormpath Thymeleaf templates. How amazing is that? Here's how.
+
+Using your favorite dependency resolution build tool like Maven or Gradle, add the stormpath-default-spring-boot-starter-|version|.jar to your project dependencies. For example:
+
+**Maven**:
+
+.. parsed-literal::
+
+    <dependency>
+        <groupId>com.stormpath.spring</groupId>
+        <artifactId>stormpath-default-spring-boot-starter</artifactId>
+        <version>\ |version|\ </version>
+    </dependency>
+
+**Gradle**:
+
+.. parsed-literal::
+
+    dependencies {
+        compile 'com.stormpath.spring:stormpath-default-spring-boot-starter:\ |version|\ '
+    }
+
+
+In order to connect Stormpath and Spring Security, we need one small configuration class in your project:
+
+.. code-block:: java
+    :emphasize-lines: 2
+
+        @Configuration
+        public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAdapter {}
+
+Without this, you will get a popup in your browser prompting for authentication, which is the default basic authentication for Spring Security.
+
+Also, by default, all paths are locked down with Spring Security. Stormpath's Spring Security integration follows this idiomatic
+behavior.
+
+That's it!  You're ready to start using Stormpath in your Spring Boot web application!  Can you believe how easy that was?
+
 Try it!
 -------
 

--- a/extensions/spring/boot/docs/source/stormpath-spring-boot-setup.txt
+++ b/extensions/spring/boot/docs/source/stormpath-spring-boot-setup.txt
@@ -31,49 +31,6 @@ All communication with Stormpath must be authenticated with an API Key.
 
 On Windows, you can `set file permissions similarly`_.
 
-.. _dependency-jar:
-
-Add the Stormpath Default Spring Boot Starter
----------------------------------------------
-
-This step allows you to enable Stormpath in a Spring Boot web app with *very minimal* configuration.
-It includes Stormpath Spring Security, Stormpath Spring WebMVC and Stormpath Thymeleaf templates. How amazing is that? Here's how.
-
-Using your favorite dependency resolution build tool like Maven or Gradle, add the stormpath-default-spring-boot-starter-|version|.jar to your project dependencies. For example:
-
-**Maven**:
-
-.. parsed-literal::
-
-    <dependency>
-        <groupId>com.stormpath.spring</groupId>
-        <artifactId>stormpath-default-spring-boot-starter</artifactId>
-        <version>\ |version|\ </version>
-    </dependency>
-
-**Gradle**:
-
-.. parsed-literal::
-
-    dependencies {
-        compile 'com.stormpath.spring:stormpath-default-spring-boot-starter:\ |version|\ '
-    }
-
-In order to connect Stormpath and Spring Security, we need one small configuration class in your project:
-
-.. code-block:: java
-    :emphasize-lines: 2
-
-    @Configuration
-    public class SpringSecurityWebAppConfig extends StormpathWebSecurityConfigurerAdapter {}
-
-Without this, you will get a popup in your browser prompting for authentication, which is the default basic authentication for Spring Security.
-
-Also, by default, all paths are locked down with Spring Security. Stormpath's Spring Security integration follows this idiomatic
-behavior.
-
-That's it!  You're ready to start using Stormpath in your Spring Boot web application!  Can you believe how easy that was?
-
 .. _examples: https://github.com/stormpath/stormpath-sdk-java/tree/master/examples
 .. _sign up for Stormpath for free: https://api.stormpath.com/register
 .. _Stormpath Admin Console: https://api.stormpath.com

--- a/extensions/spring/boot/docs/source/tutorial.rst
+++ b/extensions/spring/boot/docs/source/tutorial.rst
@@ -50,25 +50,30 @@ For a gradle build and run, do this:
 
 You should now be able to browse to `<http://localhost:8080>`_ and see a welcome message with your Stormpath application's name.
 
-This application has just two code files in it. Here's the structure:
+This application has just two code files and a properties file in it. Here's the structure:
 
 .. code-block:: bash
     :emphasize-lines: 9, 10
 
     .
     `-- src
-        `-- main
-            `-- java
-                `-- com
-                    `-- stormpath
-                        `-- tutorial
-                            |-- controller
-                            |   `-- HelloController.java
-                            `-- Application.java
+       `-- main
+           |-- java
+           |   `-- com
+           |       `-- stormpath
+           |           `-- tutorial
+           |               |-- controller
+           |               |   `-- HelloController.java
+           |               `-- Application.java
+           `-- resources
+               `-- application.properties
 
-``Application.java`` is a most basic Spring Boot application file with a ``main`` method:
+``Application.java`` is a most basic Spring Boot application file with a ``main`` method and the ``@SpringBootApplication``
+annotation:
 
 .. code-block:: java
+    :linenos:
+    :emphasize-lines: 1
 
     @SpringBootApplication
     public class Application  {
@@ -95,13 +100,19 @@ This application has just two code files in it. Here's the structure:
 Here we have our first taste of Stormpath in action. On line 5 we are getting hold of the Stormpath application and on
 line 6 we are obtaining its name for display.
 
+For this example, we don't want Spring Security locking everything down, which is its default behavior. So, we will simply
+disable it. That's where the ``application.properties`` files comes in:
+
+.. code-block:: java
+    :linenos:
+
+    stormpath.spring.security.enabled = false
+    security.basic.enabled = false
+
+The first line disables Stormpath's hooks into Spring Security and the second line disables Spring Security itself.
+
 Pretty simple setup, right? In the next section, we'll layer in some flow logic based on logged-in state. And then we
 will refine that to make use of all the Spring Security has to offer in making our lives easier.
-
-Feeling adventurous? Browse on over to ``http://localhost:8080/login``. You will see the default Stormpath login form.
-You can login in as an existing user, register a new user and even reset your password. Where did this come from? It's
-all part of the built in authentication flows that Stormpath provides. With a 1-line ``main`` method and
-a 2-line controller, you get all this functionality out of the box.
 
 .. _some-access-controls:
 

--- a/pom.xml
+++ b/pom.xml
@@ -672,6 +672,41 @@
                             </execution>
                         </executions>
                         <inherited>true</inherited>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.1.2</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <inherited>true</inherited>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>travis-docs</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-api-docs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <inherited>true</inherited>
                         <configuration>
                             <top><![CDATA[
     <script>


### PR DESCRIPTION
Quickstart retains Spring Security while beginngin of tutorial does not. Refined .travis.yml to better detect release so it doesn't publish docs twice.