### PR TITLE
Ensure that assets required to render Stormpath views are always accessible without authentication regardless of user configuration

### DIFF
--- a/extensions/servlet/src/main/resources/META-INF/com/stormpath/sdk/servlet/default.stormpath.properties
+++ b/extensions/servlet/src/main/resources/META-INF/com/stormpath/sdk/servlet/default.stormpath.properties
@@ -269,3 +269,8 @@ stormpath.web.http.authc.schemes.bearer = com.stormpath.sdk.servlet.http.authc.c
 stormpath.web.authz.unauthorizedHandler = com.stormpath.sdk.servlet.filter.config.UnauthorizedHandlerFactory
 
 stormpath.web.filter.chain.resolver = com.stormpath.sdk.servlet.config.DefaultFilterChainResolverFactory
+
+## ensure that access to assets required to render Stormpath views (login, registration, etc.)
+## are always open, regardless of user configuration
+stormpath.web.uris./assets/css/stormpath.css = anon
+stormpath.web.uris./assets/css/custom.stormpath.css = anon


### PR DESCRIPTION
If a user specifies locking down all paths in `stormpath.properties` when using the servlet plugin:

```
stormpath.web.uris./** = authc
```
It causes assets that the Stormpath views for login, registration, etc. to require authentication as well.

Currently, these assets are:

```
/assets/css/stormpath.css
/assets/css/custom.stormpath.css
```

These should always be publicly accessible regardless of user configuration.

Addresses #390 