### PR TITLE
set loginNextrUri when creating StormpathSuccessHandler so it doesn't get clobbered in Spring Security config.

### DIFF
--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebSecurityConfiguration.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebSecurityConfiguration.java
@@ -124,7 +124,9 @@ public abstract class AbstractStormpathWebSecurityConfiguration {
     }
 
     public AuthenticationSuccessHandler stormpathAuthenticationSuccessHandler() {
-        return new StormpathLoginSuccessHandler(client, authenticationResultSaver);
+        StormpathLoginSuccessHandler loginSuccessHandler = new StormpathLoginSuccessHandler(client, authenticationResultSaver);
+        loginSuccessHandler.setDefaultTargetUrl(loginNextUri);
+        return loginSuccessHandler;
     }
 
     public AuthenticationFailureHandler stormpathAuthenticationFailureHandler() {

--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebSecurityConfigurer.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebSecurityConfigurer.java
@@ -70,9 +70,6 @@ public class StormpathWebSecurityConfigurer extends SecurityConfigurerAdapter<De
     @Value("#{ @environment['stormpath.web.login.uri'] ?: '/login' }")
     protected String loginUri;
 
-    @Value("#{ @environment['stormpath.web.login.nextUri'] ?: '/' }")
-    protected String loginNextUri;
-
     @Value("#{ @environment['stormpath.web.logout.enabled'] ?: true }")
     protected boolean logoutEnabled;
 
@@ -159,8 +156,7 @@ public class StormpathWebSecurityConfigurer extends SecurityConfigurerAdapter<De
                 http
                     .formLogin()
                     .loginPage(loginUri)
-                    .defaultSuccessUrl(loginNextUri)
-                    .successHandler(successHandler)
+                    .successHandler(successHandler) // success handler will pickup the configured loginNextUri
                     .failureHandler(failureHandler)
                     .usernameParameter("login")
                     .passwordParameter("password")


### PR DESCRIPTION
*Note:* I think this is actually a Spring Security bug and I will log an issue with Rob Winch.

In the current (and many previous releases) of Spring Security, the call to `defaultSuccessUrl` instantiates a `AuthenticationSuccessHandler`, sets the `defaultSuccessUrl` in it and installs it as the configured `AuthenticationSuccessHandler`.

A subsequent call to `successHandler` clobbers the `AuthenticationSuccessHandler` that had been previously set and you end up with the default `defaultSuccessUrl` which is `/`.

However, there's an easy workaround for this which is to set the `defaultSuccessUrl` when the `StormpathLoginSuccessHandler` is instantiated.

Addresses #392 