### PR TITLE
update maven groovy plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -477,24 +477,10 @@
             </plugin>
             <plugin>
                 <!-- For unit tests: -->
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
                 <version>1.5</version>
-                <configuration>
-                    <providerSelection>1.8</providerSelection>
-                </configuration>
                 <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.gmaven.runtime</groupId>
-                        <artifactId>gmaven-runtime-1.8</artifactId>
-                        <version>1.5</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>org.codehaus.groovy</groupId>
-                                <artifactId>groovy-all</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
@@ -504,10 +490,14 @@
                 <executions>
                     <execution>
                         <goals>
+                            <goal>addSources</goal>
+                            <goal>addTestSources</goal>
                             <goal>generateStubs</goal>
                             <goal>compile</goal>
-                            <goal>generateTestStubs</goal>
+                            <goal>testGenerateStubs</goal>
                             <goal>testCompile</goal>
+                            <goal>removeStubs</goal>
+                            <goal>removeTestStubs</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
The current gmaven plugin hasn't been releases since 2012. GMavenPlus is active and was last released in March of this year.

https://github.com/groovy/gmaven
http://search.maven.org/#search%7Cga%7C1%7Cgmaven-plugin
Last released: 12/6/2012
Last commit: 12/6/2012

https://github.com/groovy/GMavenPlus
http://search.maven.org/#search%7Cga%7C1%7Cgmavenplus-plugin
Last released: 3/8/2015
Last commit: 9/24/2015