### PR TITLE
Updated code to differentiate between AccessToken and RefreshToken.

### DIFF
--- a/api/src/main/java/com/stormpath/sdk/oauth/AccessToken.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/AccessToken.java
@@ -15,12 +15,6 @@
 */
 package com.stormpath.sdk.oauth;
 
-import com.stormpath.sdk.account.Account;
-import com.stormpath.sdk.application.Application;
-import com.stormpath.sdk.resource.Deletable;
-import com.stormpath.sdk.resource.Resource;
-import com.stormpath.sdk.tenant.Tenant;
-
 /**
  * This interface represents an Authentication OAuth2 token created in Stormpath.
  * Specifically, an

--- a/api/src/main/java/com/stormpath/sdk/oauth/AccessToken.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/AccessToken.java
@@ -22,13 +22,13 @@ import com.stormpath.sdk.resource.Resource;
 import com.stormpath.sdk.tenant.Tenant;
 
 /**
- * This class represents an Authentication OAuth2 token created in Stormpath.
+ * This interface represents an Authentication OAuth2 token created in Stormpath.
  * Specifically, an
  * <a href="https://docs.stormpath.com/guides/token-management/#using-stormpath-to-generate-an-oauth-20-access-tokens">AccessToken</a>
  *
  * @since 1.0.RC7
  */
 public interface AccessToken extends BaseOauth2Token {
-    AccessToken ensureAccessToken();
+
 }
 

--- a/api/src/main/java/com/stormpath/sdk/oauth/AccessToken.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/AccessToken.java
@@ -23,37 +23,12 @@ import com.stormpath.sdk.tenant.Tenant;
 
 /**
  * This class represents an Authentication OAuth2 token created in Stormpath.
+ * Specifically, an
+ * <a href="https://docs.stormpath.com/guides/token-management/#using-stormpath-to-generate-an-oauth-20-access-tokens">AccessToken</a>
  *
  * @since 1.0.RC7
  */
-public interface AccessToken extends Resource, Deletable {
-
-    /**
-     * Returns the String representation of the Json Web Token.
-     *
-     * @return a String value denoting a JWT.
-     */
-    String getJwt();
-
-    /**
-     * Returns the {@link Account} associated to this {@link AccessToken}.
-     *
-     * @return the {@link Account} associated to this {@link AccessToken}.
-     */
-    Account getAccount();
-
-    /**
-     * Returns the {@link Application} associated to this {@link AccessToken}.
-     *
-     * @return the {@link Application} associated to this {@link AccessToken}.
-     */
-    Application getApplication();
-
-    /**
-     * Returns the {@link Tenant} this {@link AccessToken} belongs to.
-     *
-     * @return the {@link Tenant} this {@link AccessToken} belongs to.
-     */
-    Tenant getTenant();
+public interface AccessToken extends BaseOauth2Token {
+    AccessToken ensureAccessToken();
 }
 

--- a/api/src/main/java/com/stormpath/sdk/oauth/BaseOauth2Token.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/BaseOauth2Token.java
@@ -31,6 +31,7 @@ import com.stormpath.sdk.tenant.Tenant;
  * @since 1.0.RC8.3
  */
 public interface BaseOauth2Token extends Resource, Deletable {
+
     /**
      * Returns the String representation of the Json Web Token.
      *
@@ -58,4 +59,5 @@ public interface BaseOauth2Token extends Resource, Deletable {
      * @return the {@link Tenant} this {@link AccessToken} belongs to.
      */
     Tenant getTenant();
+
 }

--- a/api/src/main/java/com/stormpath/sdk/oauth/BaseOauth2Token.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/BaseOauth2Token.java
@@ -1,0 +1,61 @@
+/*
+* Copyright 2015 Stormpath, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.stormpath.sdk.oauth;
+
+import com.stormpath.sdk.account.Account;
+import com.stormpath.sdk.application.Application;
+import com.stormpath.sdk.resource.Deletable;
+import com.stormpath.sdk.resource.Resource;
+import com.stormpath.sdk.tenant.Tenant;
+
+/**
+ * This is a base interface for those methods that Stormpath
+ * {@link AccessToken}s and {@link RefreshToken}s have in common.
+ *
+ * @see AccessToken
+ * @see RefreshToken
+ *
+ * @since 1.0.RC8.3
+ */
+public interface BaseOauth2Token extends Resource, Deletable {
+    /**
+     * Returns the String representation of the Json Web Token.
+     *
+     * @return a String value denoting a JWT.
+     */
+    String getJwt();
+
+    /**
+     * Returns the {@link Account} associated to this {@link AccessToken}.
+     *
+     * @return the {@link Account} associated to this {@link AccessToken}.
+     */
+    Account getAccount();
+
+    /**
+     * Returns the {@link Application} associated to this {@link AccessToken}.
+     *
+     * @return the {@link Application} associated to this {@link AccessToken}.
+     */
+    Application getApplication();
+
+    /**
+     * Returns the {@link Tenant} this {@link AccessToken} belongs to.
+     *
+     * @return the {@link Tenant} this {@link AccessToken} belongs to.
+     */
+    Tenant getTenant();
+}

--- a/api/src/main/java/com/stormpath/sdk/oauth/RefreshToken.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/RefreshToken.java
@@ -16,9 +16,12 @@
 package com.stormpath.sdk.oauth;
 
 /**
- * This interfaces denotes a specific kind of {@link AccessToken}: a
- * <a href="https://docs.stormpath.com/guides/token-management/#refreshing-access-tokens">Refresh Token</a>.
+ * This class represents an Authentication OAuth2 token created in Stormpath.
+ * Specifically, a
+ * <a href="https://docs.stormpath.com/guides/token-management/#refreshing-access-tokens">Refresh Token</a>
  *
+ * @since 1.0.RC7
  */
-public interface RefreshToken extends AccessToken {
+public interface RefreshToken extends BaseOauth2Token {
+
 }

--- a/api/src/main/java/com/stormpath/sdk/oauth/RefreshToken.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/RefreshToken.java
@@ -16,7 +16,7 @@
 package com.stormpath.sdk.oauth;
 
 /**
- * This class represents an Authentication OAuth2 token created in Stormpath.
+ * This interface represents an Authentication OAuth2 token created in Stormpath.
  * Specifically, a
  * <a href="https://docs.stormpath.com/guides/token-management/#refreshing-access-tokens">Refresh Token</a>
  *

--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
@@ -1504,6 +1504,63 @@ class ApplicationIT extends ClientIT {
         assertNotNull Authenticators.JWT_AUTHENTICATOR.forApplication(app).withLocalValidation().authenticate(authRequest)
     }
 
+    @Test
+    void testAttemptAuthenticationWithRefreshToken() {
+        def app = createTempApp()
+        def account = createTestAccount(app)
+
+        PasswordGrantRequest grantRequest = Oauth2Requests.PASSWORD_GRANT_REQUEST.builder()
+            .setLogin(account.email)
+            .setPassword("Changeme1!")
+            .build()
+
+        def grantResult = Authenticators.PASSWORD_GRANT_AUTHENTICATOR
+            .forApplication(app)
+            .authenticate(grantRequest)
+
+        // Authenticate token against Stormpath using refresh token <--- INVALID
+        JwtAuthenticationRequest authRequest = Oauth2Requests.JWT_AUTHENTICATION_REQUEST.builder()
+            .setJwt(grantResult.getRefreshTokenString())
+            .build()
+
+        try {
+            Authenticators.JWT_AUTHENTICATOR.forApplication(app).authenticate(authRequest)
+            fail("Should have thrown")
+        } catch (Exception e) {
+            def message = e.getMessage()
+            assertTrue message.equals("JWT failed validation; it cannot be trusted.")
+        }
+    }
+
+    @Test
+    void testAttemptAuthenticationWithRefreshTokenWithLocalValidation() {
+        def app = createTempApp()
+        def account = createTestAccount(app)
+
+        PasswordGrantRequest grantRequest = Oauth2Requests.PASSWORD_GRANT_REQUEST.builder()
+                .setLogin(account.email)
+                .setPassword("Changeme1!")
+                .build()
+
+        def grantResult = Authenticators.PASSWORD_GRANT_AUTHENTICATOR
+                .forApplication(app)
+                .authenticate(grantRequest)
+
+        // Authenticate token against Stormpath using refresh token <--- INVALID
+        JwtAuthenticationRequest authRequest = Oauth2Requests.JWT_AUTHENTICATION_REQUEST.builder()
+                .setJwt(grantResult.getRefreshTokenString())
+                .build()
+
+        try {
+            Authenticators.JWT_AUTHENTICATOR.forApplication(app).withLocalValidation().authenticate(authRequest)
+            fail("Should have thrown")
+        } catch (Exception e) {
+            def message = e.getMessage()
+            assertTrue message.equals("JWT failed validation; it cannot be trusted.")
+        }
+    }
+
+
     /* @since 1.0.RC7 */
     @Test
     void testInvalidTokenViaLocalValidation() {

--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
@@ -1504,6 +1504,7 @@ class ApplicationIT extends ClientIT {
         assertNotNull Authenticators.JWT_AUTHENTICATOR.forApplication(app).withLocalValidation().authenticate(authRequest)
     }
 
+    /* @since 1.0.RC8.3 */
     @Test
     void testAttemptAuthenticationWithRefreshToken() {
         def app = createTempApp()
@@ -1532,6 +1533,7 @@ class ApplicationIT extends ClientIT {
         }
     }
 
+    /* @since 1.0.RC8.3 */
     @Test
     void testAttemptAuthenticationWithRefreshTokenWithLocalValidation() {
         def app = createTempApp()

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/AbstractBaseOauth2Token.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/AbstractBaseOauth2Token.java
@@ -14,6 +14,9 @@ import com.stormpath.sdk.tenant.Tenant;
 import java.util.Date;
 import java.util.Map;
 
+/**
+ * @since 1.0.RC8.3
+ */
 public abstract class AbstractBaseOauth2Token extends AbstractInstanceResource implements BaseOauth2Token {
 
     static final String ACCOUNT_PROP_NAME = "account";

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/AbstractBaseOauth2Token.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/AbstractBaseOauth2Token.java
@@ -14,7 +14,7 @@ import com.stormpath.sdk.tenant.Tenant;
 import java.util.Date;
 import java.util.Map;
 
-public class DefaultBaseOauth2Token extends AbstractInstanceResource implements BaseOauth2Token {
+public abstract class AbstractBaseOauth2Token extends AbstractInstanceResource implements BaseOauth2Token {
 
     static final String ACCOUNT_PROP_NAME = "account";
     static final String APPLICATION_PROP_NAME = "application";
@@ -31,11 +31,11 @@ public class DefaultBaseOauth2Token extends AbstractInstanceResource implements 
 
     static final Map<String, Property> PROPERTY_DESCRIPTORS = createPropertyDescriptorMap(JWT, ACCOUNT, APPLICATION, TENANT, CREATED_AT);
 
-    public DefaultBaseOauth2Token(InternalDataStore dataStore) {
+    public AbstractBaseOauth2Token(InternalDataStore dataStore) {
         super(dataStore);
     }
 
-    public DefaultBaseOauth2Token(InternalDataStore dataStore, Map<String, Object> properties) {
+    public AbstractBaseOauth2Token(InternalDataStore dataStore, Map<String, Object> properties) {
         super(dataStore, properties);
     }
 

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
@@ -38,8 +38,7 @@ public class DefaultAccessToken extends DefaultBaseOauth2Token implements Access
         super(dataStore, properties);
     }
 
-    @Override
-    public AccessToken ensureAccessToken() {
+    protected AccessToken ensureAccessToken() {
         try {
             Claims claims = Jwts.parser()
                 .setSigningKey(getDataStore().getApiKey().getSecret().getBytes("UTF-8"))

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
@@ -28,7 +28,7 @@ import java.util.Map;
 /**
  * @since 1.0.RC7
  */
-public class DefaultAccessToken extends DefaultBaseOauth2Token implements AccessToken {
+public class DefaultAccessToken extends AbstractBaseOauth2Token implements AccessToken {
 
     public DefaultAccessToken(InternalDataStore dataStore, Map<String, Object> properties) {
         super(dataStore, properties);

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
@@ -30,15 +30,12 @@ import java.util.Map;
  */
 public class DefaultAccessToken extends DefaultBaseOauth2Token implements AccessToken {
 
-    public DefaultAccessToken(InternalDataStore dataStore) {
-        super(dataStore);
-    }
-
     public DefaultAccessToken(InternalDataStore dataStore, Map<String, Object> properties) {
         super(dataStore, properties);
+        ensureAccessToken();
     }
 
-    protected AccessToken ensureAccessToken() {
+    private void ensureAccessToken() {
         try {
             Claims claims = Jwts.parser()
                 .setSigningKey(getDataStore().getApiKey().getSecret().getBytes("UTF-8"))
@@ -47,7 +44,6 @@ public class DefaultAccessToken extends DefaultBaseOauth2Token implements Access
             // token *must* have an rti claim to be an access_token
             // otherwise, it may be a refresh_token trying to be passed off as an access_token
             Assert.isTrue(Strings.hasText((String) claims.get("rti")));
-            return this;
         } catch (Exception e) {
             throw new JwtException("JWT failed validation; it cannot be trusted.");
         }

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
@@ -35,6 +35,14 @@ public class DefaultAccessToken extends AbstractBaseOauth2Token implements Acces
         ensureAccessToken();
     }
 
+    /**
+     * This method will validate that the received jwt corresponds to an `access_token` (as opposed to a
+     * `refresh_token`). If that is not the case then this operation will throw a JwtException. It is called
+     * from the constructor, so an AccessToken cannot be instantiated without verifying the jwt is a proper
+     * `access_token`
+     * 
+     * @since 1.0.RC8.3
+     */
     private void ensureAccessToken() {
         try {
             Claims claims = Jwts.parser()

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
@@ -15,35 +15,20 @@
 */
 package com.stormpath.sdk.impl.oauth;
 
-import com.stormpath.sdk.account.Account;
-import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.impl.ds.InternalDataStore;
-import com.stormpath.sdk.impl.resource.*;
+import com.stormpath.sdk.lang.Assert;
+import com.stormpath.sdk.lang.Strings;
 import com.stormpath.sdk.oauth.AccessToken;
-import com.stormpath.sdk.tenant.Tenant;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 
-import java.util.Date;
 import java.util.Map;
 
 /**
  * @since 1.0.RC7
  */
-public class DefaultAccessToken extends AbstractInstanceResource implements AccessToken {
-
-    static final String ACCOUNT_PROP_NAME = "account";
-    static final String APPLICATION_PROP_NAME = "application";
-    static final String JWT_PROP_NAME = "jwt";
-    static final String TENANT_PROP_NAME = "tenant";
-
-    static final StringProperty JWT = new StringProperty(JWT_PROP_NAME);
-    static final DateProperty CREATED_AT = new DateProperty("created_at");
-
-    // INSTANCE RESOURCE REFERENCES:
-    static final ResourceReference<Account> ACCOUNT = new ResourceReference<Account>(ACCOUNT_PROP_NAME, Account.class);
-    static final ResourceReference<Application> APPLICATION = new ResourceReference<Application>(APPLICATION_PROP_NAME, Application.class);
-    static final ResourceReference<Tenant> TENANT = new ResourceReference<Tenant>(TENANT_PROP_NAME, Tenant.class);
-
-    static final Map<String, Property> PROPERTY_DESCRIPTORS = createPropertyDescriptorMap(JWT, ACCOUNT, APPLICATION, TENANT, CREATED_AT);
+public class DefaultAccessToken extends DefaultBaseOauth2Token implements AccessToken {
 
     public DefaultAccessToken(InternalDataStore dataStore) {
         super(dataStore);
@@ -53,37 +38,19 @@ public class DefaultAccessToken extends AbstractInstanceResource implements Acce
         super(dataStore, properties);
     }
 
-    public Date getCreatedAt() {
-        return getDateProperty(CREATED_AT);
-    }
-
     @Override
-    public Map<String, Property> getPropertyDescriptors() {
-        return PROPERTY_DESCRIPTORS;
-    }
+    public AccessToken ensureAccessToken() {
+        try {
+            Claims claims = Jwts.parser()
+                .setSigningKey(getDataStore().getApiKey().getSecret().getBytes("UTF-8"))
+                .parseClaimsJws(getString(JWT)).getBody();
 
-    @Override
-    public String getJwt() {
-        return getString(JWT);
-    }
-
-    @Override
-    public Account getAccount() {
-        return getResourceProperty(ACCOUNT);
-    }
-
-    @Override
-    public Application getApplication() {
-        return getResourceProperty(APPLICATION);
-    }
-
-    @Override
-    public Tenant getTenant() {
-        return getResourceProperty(TENANT);
-    }
-
-    @Override
-    public void delete() {
-        getDataStore().delete(this);
+            // token *must* have an rti claim to be an access_token
+            // otherwise, it may be a refresh_token trying to be passed off as an access_token
+            Assert.isTrue(Strings.hasText((String) claims.get("rti")));
+            return this;
+        } catch (Exception e) {
+            throw new JwtException("JWT failed validation; it cannot be trusted.");
+        }
     }
 }

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultBaseOauth2Token.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultBaseOauth2Token.java
@@ -15,6 +15,7 @@ import java.util.Date;
 import java.util.Map;
 
 public class DefaultBaseOauth2Token extends AbstractInstanceResource implements BaseOauth2Token {
+
     static final String ACCOUNT_PROP_NAME = "account";
     static final String APPLICATION_PROP_NAME = "application";
     static final String JWT_PROP_NAME = "jwt";

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultBaseOauth2Token.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultBaseOauth2Token.java
@@ -1,0 +1,76 @@
+package com.stormpath.sdk.impl.oauth;
+
+import com.stormpath.sdk.account.Account;
+import com.stormpath.sdk.application.Application;
+import com.stormpath.sdk.impl.ds.InternalDataStore;
+import com.stormpath.sdk.impl.resource.AbstractInstanceResource;
+import com.stormpath.sdk.impl.resource.DateProperty;
+import com.stormpath.sdk.impl.resource.Property;
+import com.stormpath.sdk.impl.resource.ResourceReference;
+import com.stormpath.sdk.impl.resource.StringProperty;
+import com.stormpath.sdk.oauth.BaseOauth2Token;
+import com.stormpath.sdk.tenant.Tenant;
+
+import java.util.Date;
+import java.util.Map;
+
+public class DefaultBaseOauth2Token extends AbstractInstanceResource implements BaseOauth2Token {
+    static final String ACCOUNT_PROP_NAME = "account";
+    static final String APPLICATION_PROP_NAME = "application";
+    static final String JWT_PROP_NAME = "jwt";
+    static final String TENANT_PROP_NAME = "tenant";
+
+    static final StringProperty JWT = new StringProperty(JWT_PROP_NAME);
+    static final DateProperty CREATED_AT = new DateProperty("created_at");
+
+    // INSTANCE RESOURCE REFERENCES:
+    static final ResourceReference<Account> ACCOUNT = new ResourceReference<Account>(ACCOUNT_PROP_NAME, Account.class);
+    static final ResourceReference<Application> APPLICATION = new ResourceReference<Application>(APPLICATION_PROP_NAME, Application.class);
+    static final ResourceReference<Tenant> TENANT = new ResourceReference<Tenant>(TENANT_PROP_NAME, Tenant.class);
+
+    static final Map<String, Property> PROPERTY_DESCRIPTORS = createPropertyDescriptorMap(JWT, ACCOUNT, APPLICATION, TENANT, CREATED_AT);
+
+    public DefaultBaseOauth2Token(InternalDataStore dataStore) {
+        super(dataStore);
+    }
+
+    public DefaultBaseOauth2Token(InternalDataStore dataStore, Map<String, Object> properties) {
+        super(dataStore, properties);
+    }
+
+
+    public Date getCreatedAt() {
+        return getDateProperty(CREATED_AT);
+    }
+
+    @Override
+    public Map<String, Property> getPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    public String getJwt() {
+        return getString(JWT);
+    }
+
+    @Override
+    public Account getAccount() {
+        return getResourceProperty(ACCOUNT);
+    }
+
+    @Override
+    public Application getApplication() {
+        return getResourceProperty(APPLICATION);
+    }
+
+    @Override
+    public Tenant getTenant() {
+        return getResourceProperty(TENANT);
+    }
+
+    @Override
+    public void delete() {
+        getDataStore().delete(this);
+    }
+
+}

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultJwtAuthenticator.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultJwtAuthenticator.java
@@ -98,7 +98,7 @@ public class DefaultJwtAuthenticator extends AbstractOauth2Authenticator impleme
         stringBuilder.append(OAUTH_TOKEN_PATH);
         stringBuilder.append(jwtRequest.getJwt());
         AccessToken accessToken =
-            dataStore.getResource(stringBuilder.toString(), AccessToken.class).ensureAccessToken();
+            dataStore.getResource(stringBuilder.toString(), DefaultAccessToken.class).ensureAccessToken();
 
         JwtAuthenticationResultBuilder builder = new DefaultJwtAuthenticationResultBuilder(accessToken);
         return builder.build();

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultJwtAuthenticator.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultJwtAuthenticator.java
@@ -19,9 +19,12 @@ import com.stormpath.sdk.account.Account;
 import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.ds.DataStore;
 import com.stormpath.sdk.impl.account.DefaultAccount;
-import com.stormpath.sdk.oauth.JwtAuthenticationResult;
 import com.stormpath.sdk.lang.Assert;
-import com.stormpath.sdk.oauth.*;
+import com.stormpath.sdk.oauth.AccessToken;
+import com.stormpath.sdk.oauth.JwtAuthenticationRequest;
+import com.stormpath.sdk.oauth.JwtAuthenticationResult;
+import com.stormpath.sdk.oauth.JwtAuthenticator;
+import com.stormpath.sdk.oauth.Oauth2AuthenticationRequest;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -81,7 +84,7 @@ public class DefaultJwtAuthenticator extends AbstractOauth2Authenticator impleme
                 properties.put(DefaultAccessToken.JWT_PROP_NAME, jwtRequest.getJwt());
                 properties.put(DefaultAccessToken.TENANT_PROP_NAME, application.getTenant());
 
-                AccessToken accessToken = new DefaultAccessToken(dataStore, properties);
+                AccessToken accessToken = new DefaultAccessToken(dataStore, properties).ensureAccessToken();
 
                 JwtAuthenticationResultBuilder builder = new DefaultJwtAuthenticationResultBuilder(accessToken);
                 return builder.build();
@@ -94,7 +97,9 @@ public class DefaultJwtAuthenticator extends AbstractOauth2Authenticator impleme
         StringBuilder stringBuilder = new StringBuilder(application.getHref());
         stringBuilder.append(OAUTH_TOKEN_PATH);
         stringBuilder.append(jwtRequest.getJwt());
-        AccessToken accessToken = dataStore.getResource(stringBuilder.toString(), AccessToken.class);
+        AccessToken accessToken =
+            dataStore.getResource(stringBuilder.toString(), AccessToken.class).ensureAccessToken();
+
         JwtAuthenticationResultBuilder builder = new DefaultJwtAuthenticationResultBuilder(accessToken);
         return builder.build();
     }

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultRefreshToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultRefreshToken.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * @since 1.0.RC7
  */
-public class DefaultRefreshToken extends DefaultAccessToken implements RefreshToken {
+public class DefaultRefreshToken extends DefaultBaseOauth2Token implements RefreshToken {
 
     public DefaultRefreshToken(InternalDataStore dataStore) {
         super(dataStore);

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultRefreshToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultRefreshToken.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * @since 1.0.RC7
  */
-public class DefaultRefreshToken extends DefaultBaseOauth2Token implements RefreshToken {
+public class DefaultRefreshToken extends AbstractBaseOauth2Token implements RefreshToken {
 
     public DefaultRefreshToken(InternalDataStore dataStore) {
         super(dataStore);

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultAccessTokenTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultAccessTokenTest.groovy
@@ -17,6 +17,7 @@ package com.stormpath.sdk.impl.oauth
 
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat
 import com.stormpath.sdk.account.Account
+import com.stormpath.sdk.api.ApiKey
 import com.stormpath.sdk.application.Application
 import com.stormpath.sdk.impl.account.DefaultAccount
 import com.stormpath.sdk.impl.application.DefaultApplication
@@ -41,29 +42,13 @@ import static org.testng.Assert.*
 class DefaultAccessTokenTest {
 
     @Test
-    void testGetPropertyDescriptors() {
-
-        def defaultAccessToken = new DefaultAccessToken(createStrictMock(InternalDataStore))
-
-        def propertyDescriptors = defaultAccessToken.getPropertyDescriptors()
-
-        assertEquals(propertyDescriptors.size(), 5)
-
-        assertTrue(propertyDescriptors.get("jwt") instanceof StringProperty)
-        assertTrue(propertyDescriptors.get("created_at") instanceof DateProperty)
-
-        assertTrue(propertyDescriptors.get("tenant") instanceof ResourceReference && propertyDescriptors.get("tenant").getType().equals(Tenant))
-        assertTrue(propertyDescriptors.get("application") instanceof ResourceReference && propertyDescriptors.get("application").getType().equals(Application))
-        assertTrue(propertyDescriptors.get("account") instanceof ResourceReference && propertyDescriptors.get("account").getType().equals(Account))
-    }
-
-    @Test
     void testMethods() {
 
         DateFormat df = new ISO8601DateFormat();
 
-        def properties = [href: "https://api.stormpath.com/v1/accessTokens/5hFj6FUwNb28OQrp93phPP",
-            jwt: "eyJraWQiOiI2UDVKTjRTQVMwOFFIRlhNTzdGNTY4Ukc2IiwiYWxnIjoiSFMyNT",
+        def properties = [
+            href: "https://api.stormpath.com/v1/accessTokens/5hFj6FUwNb28OQrp93phPP",
+            jwt: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRGVlciIsImFkbWluIjp0cnVlLCJydGkiOiJhYmNkZWZnIn0.7jqji4K--V-Xi5WeaEg29UnAho4bCpwkSwEuAf8MJtQ",
             tenant: [href: "https://api.stormpath.com/v1/tenants/jdhrgojeorigjj09etiij"],
             application: [href: "https://api.stormpath.com/v1/applications/928glsjeorigjj09etiij"],
             account: [href: "https://api.stormpath.com/v1/accounts/apsd98f2kj09etiij"],
@@ -71,17 +56,23 @@ class DefaultAccessTokenTest {
         ]
 
         def internalDataStore = createStrictMock(InternalDataStore)
-        def defaultAccessToken = new DefaultAccessToken(internalDataStore, properties)
+        def apiKey = createStrictMock(ApiKey)
 
-        assertEquals(defaultAccessToken.getHref(), properties.href)
-        assertEquals(defaultAccessToken.getJwt(), properties.jwt)
-        assertEquals(df.format(defaultAccessToken.getCreatedAt()), "2015-01-01T00:00:00Z", properties.created_at)
+        expect(apiKey.getSecret()).andReturn("a_very_secret_key")
 
+        expect(internalDataStore.getApiKey()).andReturn(apiKey)
         expect(internalDataStore.instantiate(Tenant, properties.tenant)).andReturn(new DefaultTenant(internalDataStore, properties.tenant))
         expect(internalDataStore.instantiate(Account, properties.account)).andReturn(new DefaultAccount(internalDataStore, properties.account))
         expect(internalDataStore.instantiate(Application, properties.application)).andReturn(new DefaultApplication(internalDataStore, properties.application))
 
         replay internalDataStore
+        replay apiKey
+
+        def defaultAccessToken = new DefaultAccessToken(internalDataStore, properties)
+
+        assertEquals(defaultAccessToken.getHref(), properties.href)
+        assertEquals(defaultAccessToken.getJwt(), properties.jwt)
+        assertEquals(df.format(defaultAccessToken.getCreatedAt()), "2015-01-01T00:00:00Z", properties.created_at)
 
         def tenant = defaultAccessToken.getTenant()
         assertTrue(tenant instanceof Tenant && tenant.getHref().equals(properties.tenant.href))

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultAccessTokenTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultAccessTokenTest.groovy
@@ -97,6 +97,7 @@ class DefaultAccessTokenTest {
         assertTrue(application instanceof Application && application.getHref().equals(properties.application.href))
     }
 
+    /* @since 1.0.RC8.3 */
     @Test
     void testInvalidAccessToken() {
         def secret = "a_very_secret_key"
@@ -131,6 +132,7 @@ class DefaultAccessTokenTest {
         }
     }
 
+    /* @since 1.0.RC8.3 */
     @Test
     void testValidAccessToken() {
         def secret = "a_very_secret_key"

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultAccessTokenTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultAccessTokenTest.groovy
@@ -44,6 +44,7 @@ import static org.testng.Assert.*
  */
 class DefaultAccessTokenTest {
 
+    @Test
     void testGetPropertyDescriptors() {
         def secret = "a_very_secret_key"
         def href = "https://api.stormpath.com/v1/accessTokens/5hFj6FUwNb28OQrp93phPP"


### PR DESCRIPTION
Previously, RefreshToken inherited from AccessToken. Per the oauth2 spec, this is incorrect.

This PR moves common implementation into a base class and provides a method for ensuring that an AccessToken is really an AccessToken.