### PR TITLE
Avoid 2 api calls revoke tokens

### DIFF
--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/event/TokenRevocationRequestEventListener.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/event/TokenRevocationRequestEventListener.java
@@ -1,21 +1,22 @@
 /*
- * Copyright 2016 Stormpath, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright 2016 Stormpath, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package com.stormpath.sdk.servlet.event;
 
 import com.stormpath.sdk.client.Client;
+import com.stormpath.sdk.impl.ds.DefaultDataStore;
 import com.stormpath.sdk.oauth.AccessToken;
 import com.stormpath.sdk.oauth.RefreshToken;
 import com.stormpath.sdk.resource.ResourceException;
@@ -35,10 +36,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.security.Key;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
- * @since 1.0.RC8.3
- */
+* @since 1.0.RC8.3
+*/
 public class TokenRevocationRequestEventListener implements RequestEventListener {
 
     private static final Logger log = LoggerFactory.getLogger(TokenRevocationRequestEventListener.class);
@@ -46,8 +49,6 @@ public class TokenRevocationRequestEventListener implements RequestEventListener
     private final TokenExtractor tokenExtractor = new BearerHeaderTokenExtractor();
 
     private final JwtTokenSigningKeyResolver jwtTokenSigningKeyResolver = new JwtTokenSigningKeyResolver();
-
-    private final SignatureAlgorithm alg = SignatureAlgorithm.HS256;
 
     private Client client = null;
 
@@ -76,7 +77,7 @@ public class TokenRevocationRequestEventListener implements RequestEventListener
         String jwt = tokenExtractor.getAccessToken(e.getRequest());
         if (jwt != null) {
             if (this.client == null) {
-                this.client = ClientResolver.INSTANCE.getClient(e.getRequest());
+                this.client = ClientResolver.INSTANCE.getClient(e.getRequest()); //will throw if not found
             }
 
             Key signingKey = jwtTokenSigningKeyResolver.getSigningKey(e.getRequest(), e.getResponse(), null, SignatureAlgorithm.HS256);
@@ -101,27 +102,33 @@ public class TokenRevocationRequestEventListener implements RequestEventListener
         return claims.containsKey("rti");
     }
 
-    private void gracefullyDeleteAccessToken(String resourceID) {
+    private void gracefullyDeleteAccessToken(String accessTokenId) {
         try {
-            AccessToken accessToken = client.getResource("/accessTokens/" + resourceID, AccessToken.class);
+            String href = "/accessTokens/" + accessTokenId;
+            Map<String, Object> map = new LinkedHashMap<String, Object>();
+            map.put("href", href);
+            AccessToken accessToken = ((DefaultDataStore)client.getDataStore()).instantiate(AccessToken.class, map, null, true);
             accessToken.delete();
         } catch (ResourceException e) {
             //Let's prevent an error to avoid the flow to continue (failing to try to delete an access token for example)
             if (log.isDebugEnabled()) {
-                log.debug("There was an error trying to delete a refresh token with ID " + resourceID + ". Exception was: " + e.getStackTrace());
+                log.debug("There was an error trying to delete access token with ID " + accessTokenId + ". Exception was: " + e.getStackTrace());
             }
         }
     }
 
-    private void gracefullyDeleteRefreshToken(String resourceID) {
+    private void gracefullyDeleteRefreshToken(String refreshTokenId) {
         try{
-            RefreshToken refreshToken = client.getResource("/refreshTokens/" + resourceID, RefreshToken.class);
+            String href =  "/refreshTokens/" + refreshTokenId;
+            Map<String, Object> map = new LinkedHashMap<String, Object>();
+            map.put("href", href);
+            RefreshToken refreshToken = ((DefaultDataStore)client.getDataStore()).instantiate(RefreshToken.class, map, null, true);
             refreshToken.delete();
         } catch (ResourceException e) {
             //Let's prevent an error to avoid the flow to continue, this component is basically a listener that tries to delete
             //access tokens on logout, we will only post this error in the log
             if (log.isDebugEnabled()) {
-                log.debug("There was an error trying to delete an access token with ID " + resourceID + ". Exception was: " + e.getStackTrace());
+                log.debug("There was an error trying to delete refresh token with ID " + refreshTokenId + ". Exception was: " + e.getStackTrace());
             }
         }
     }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/event/TokenRevocationRequestEventListener.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/event/TokenRevocationRequestEventListener.java
@@ -53,34 +53,34 @@ public class TokenRevocationRequestEventListener implements RequestEventListener
     private Client client = null;
 
     @Override
-    public void on(SuccessfulAuthenticationRequestEvent e) {
+    public void on(SuccessfulAuthenticationRequestEvent event) {
         //No-op
     }
 
     @Override
-    public void on(FailedAuthenticationRequestEvent e) {
+    public void on(FailedAuthenticationRequestEvent event) {
         //No-op
     }
 
     @Override
-    public void on(RegisteredAccountRequestEvent e) {
+    public void on(RegisteredAccountRequestEvent event) {
         //No-op
     }
 
     @Override
-    public void on(VerifiedAccountRequestEvent e) {
+    public void on(VerifiedAccountRequestEvent event) {
         //No-op
     }
 
     @Override
-    public void on(LogoutRequestEvent e) {
-        String jwt = tokenExtractor.getAccessToken(e.getRequest());
+    public void on(LogoutRequestEvent event) {
+        String jwt = tokenExtractor.getAccessToken(event.getRequest());
         if (jwt != null) {
             if (this.client == null) {
-                this.client = ClientResolver.INSTANCE.getClient(e.getRequest()); //will throw if not found
+                this.client = ClientResolver.INSTANCE.getClient(event.getRequest()); //will throw if not found
             }
 
-            Key signingKey = jwtTokenSigningKeyResolver.getSigningKey(e.getRequest(), e.getResponse(), null, SignatureAlgorithm.HS256);
+            Key signingKey = jwtTokenSigningKeyResolver.getSigningKey(event.getRequest(), event.getResponse(), null, SignatureAlgorithm.HS256);
             Claims claims = Jwts.parser().setSigningKey(signingKey.getEncoded()).parseClaimsJws(jwt).getBody();
 
             //Let's be sure this jwt is actually an access token otherwise we will have an error when trying to retrieve
@@ -94,7 +94,7 @@ public class TokenRevocationRequestEventListener implements RequestEventListener
             //obtaining a new access token
         }
         if (log.isDebugEnabled()) {
-            log.debug("The current access and refresh tokens for {} have been revoked.", e.getAccount().getEmail());
+            log.debug("The current access and refresh tokens for {} have been revoked.", event.getAccount().getEmail());
         }
     }
 

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/event/TokenRevocationRequestEventListener.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/event/TokenRevocationRequestEventListener.java
@@ -16,7 +16,7 @@
 package com.stormpath.sdk.servlet.event;
 
 import com.stormpath.sdk.client.Client;
-import com.stormpath.sdk.impl.ds.DefaultDataStore;
+import com.stormpath.sdk.impl.ds.InternalDataStore;
 import com.stormpath.sdk.oauth.AccessToken;
 import com.stormpath.sdk.oauth.RefreshToken;
 import com.stormpath.sdk.resource.ResourceException;
@@ -107,7 +107,7 @@ public class TokenRevocationRequestEventListener implements RequestEventListener
             String href = "/accessTokens/" + accessTokenId;
             Map<String, Object> map = new LinkedHashMap<String, Object>();
             map.put("href", href);
-            AccessToken accessToken = ((DefaultDataStore)client.getDataStore()).instantiate(AccessToken.class, map, null, true);
+            AccessToken accessToken = ((InternalDataStore)client.getDataStore()).instantiate(AccessToken.class, map, true);
             accessToken.delete();
         } catch (ResourceException e) {
             //Let's prevent an error to avoid the flow to continue
@@ -120,7 +120,7 @@ public class TokenRevocationRequestEventListener implements RequestEventListener
             String href =  "/refreshTokens/" + refreshTokenId;
             Map<String, Object> map = new LinkedHashMap<String, Object>();
             map.put("href", href);
-            RefreshToken refreshToken = ((DefaultDataStore)client.getDataStore()).instantiate(RefreshToken.class, map, null, true);
+            RefreshToken refreshToken = ((InternalDataStore)client.getDataStore()).instantiate(RefreshToken.class, map, true);
             refreshToken.delete();
         } catch (ResourceException e) {
             //Let's prevent an error to avoid the flow to continue, this component is basically a listener that tries to delete

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/event/TokenRevocationRequestEventListener.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/event/TokenRevocationRequestEventListener.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2016 Stormpath, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.stormpath.sdk.servlet.event;
 
 import com.stormpath.sdk.client.Client;
@@ -40,8 +40,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
-* @since 1.0.RC8.3
-*/
+ * @since 1.0.RC8.3
+ */
 public class TokenRevocationRequestEventListener implements RequestEventListener {
 
     private static final Logger log = LoggerFactory.getLogger(TokenRevocationRequestEventListener.class);
@@ -94,7 +94,7 @@ public class TokenRevocationRequestEventListener implements RequestEventListener
             //obtaining a new access token
         }
         if (log.isDebugEnabled()) {
-            log.debug("The current access and refresh token for {} has been revoked.", e.getAccount().getEmail());
+            log.debug("The current access and refresh tokens for {} have been revoked.", e.getAccount().getEmail());
         }
     }
 
@@ -110,10 +110,8 @@ public class TokenRevocationRequestEventListener implements RequestEventListener
             AccessToken accessToken = ((DefaultDataStore)client.getDataStore()).instantiate(AccessToken.class, map, null, true);
             accessToken.delete();
         } catch (ResourceException e) {
-            //Let's prevent an error to avoid the flow to continue (failing to try to delete an access token for example)
-            if (log.isDebugEnabled()) {
-                log.debug("There was an error trying to delete access token with ID " + accessTokenId + ". Exception was: " + e.getStackTrace());
-            }
+            //Let's prevent an error to avoid the flow to continue
+            log.error("There was an error trying to delete access token with ID " + accessTokenId + ". Exception was: " + e.getStackTrace());
         }
     }
 
@@ -126,10 +124,8 @@ public class TokenRevocationRequestEventListener implements RequestEventListener
             refreshToken.delete();
         } catch (ResourceException e) {
             //Let's prevent an error to avoid the flow to continue, this component is basically a listener that tries to delete
-            //access tokens on logout, we will only post this error in the log
-            if (log.isDebugEnabled()) {
-                log.debug("There was an error trying to delete refresh token with ID " + refreshTokenId + ". Exception was: " + e.getStackTrace());
-            }
+            //the current access and refresh tokens on logout, we will only post this error in the log
+            log.error("There was an error trying to delete refresh token with ID " + refreshTokenId + ". Exception was: " + e.getStackTrace());
         }
     }
 }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/account/ImmutableAccount.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/account/ImmutableAccount.java
@@ -245,19 +245,19 @@ public class ImmutableAccount implements Account {
         return null;
     }
 
-    /** @version 1.0.RC4 */
+    /** @since 1.0.RC4 */
     @Override
     public ApplicationList getApplications() {
         return account.getApplications();
     }
 
-    /** @version 1.0.RC4 */
+    /** @since 1.0.RC4 */
     @Override
     public ApplicationList getApplications(Map<String, Object> queryParams) {
         return account.getApplications(queryParams);
     }
 
-    /** @version 1.0.RC4 */
+    /** @since 1.0.RC4 */
     @Override
     public ApplicationList getApplications(ApplicationCriteria criteria) {
         return account.getApplications(criteria);

--- a/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/test/groovy/com/stormpath/spring/boot/autoconfigure/StormpathWebSecurityAutoConfigurationIT.groovy
+++ b/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/test/groovy/com/stormpath/spring/boot/autoconfigure/StormpathWebSecurityAutoConfigurationIT.groovy
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertEquals
 @SpringApplicationConfiguration(classes = [StormpathWebSecurityAutoConfigurationApplication.class, TwoAppTenantStormpathConfiguration.class])
 @WebAppConfiguration
 class StormpathWebSecurityAutoConfigurationIT extends AbstractTestNGSpringContextTests {
+
     @Autowired
     CsrfTokenManager csrfTokenManager
 
@@ -39,5 +40,4 @@ class StormpathWebSecurityAutoConfigurationIT extends AbstractTestNGSpringContex
     void testCsrfTokenManager() {
         assertEquals csrfTokenManager.tokenName, 'csrfToken'
     }
-
 }

--- a/extensions/spring/stormpath-spring-security/src/main/java/com/stormpath/spring/security/token/ProviderAuthenticationToken.java
+++ b/extensions/spring/stormpath-spring-security/src/main/java/com/stormpath/spring/security/token/ProviderAuthenticationToken.java
@@ -20,7 +20,7 @@ import com.stormpath.sdk.lang.Assert;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 
 /**
- * @version 1.0.RC7.2
+ * @since 1.0.RC7.2
  */
 public class ProviderAuthenticationToken extends AbstractAuthenticationToken {
 

--- a/impl/src/main/java/com/stormpath/sdk/impl/ds/DefaultDataStore.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/ds/DefaultDataStore.java
@@ -180,6 +180,25 @@ public class DefaultDataStore implements InternalDataStore {
         return this.resourceFactory.instantiate(clazz, properties);
     }
 
+    /**
+     * **Only intended for internal use, not exposed in the API**
+     * <p>Convenience method that returns a new resource instance without contacting the backend. This operation allows
+     * the <code>href</code> to be a fragment, where the <code>baseUrl</code> can be missing and will be added automatically.<p/>
+     * @param hrefFragment when <code>true</code>, the baseUrl will be appended to the value found in the href key of the properties map.
+     *                     If <code>false</code> the href will not be altered and will be kept as-is.
+     * @return a resource instance corresponding to the specified clazz.
+     * @version 1.0.RC9
+     */
+    public <T extends Resource> T instantiate(Class<T> clazz, Map<String, Object> properties, QueryString qs, boolean hrefFragment) {
+        if (hrefFragment) {
+            Assert.hasText((String) properties.get("href"), "when hrefFragment is set to true the properties map must contain an href key.");
+            String hrefValue = (String) properties.get("href");
+            hrefValue = qualify(hrefValue);
+            properties.put("href", hrefValue);
+        }
+        return this.instantiate(clazz, properties, qs);
+    }
+
     /* =====================================================================
        Resource Retrieval
        ===================================================================== */

--- a/impl/src/main/java/com/stormpath/sdk/impl/ds/DefaultDataStore.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/ds/DefaultDataStore.java
@@ -171,7 +171,6 @@ public class DefaultDataStore implements InternalDataStore {
     }
 
     private <T extends Resource> T instantiate(Class<T> clazz, Map<String, ?> properties, QueryString qs) {
-
         if (CollectionResource.class.isAssignableFrom(clazz)) {
             //only collections can support a query string constructor argument:
             return this.resourceFactory.instantiate(clazz, properties, qs);
@@ -180,23 +179,15 @@ public class DefaultDataStore implements InternalDataStore {
         return this.resourceFactory.instantiate(clazz, properties);
     }
 
-    /**
-     * **Only intended for internal use, not exposed in the API**
-     * <p>Convenience method that returns a new resource instance without contacting the backend. This operation allows
-     * the <code>href</code> to be a fragment, where the <code>baseUrl</code> can be missing and will be added automatically.<p/>
-     * @param hrefFragment when <code>true</code>, the baseUrl will be appended to the value found in the href key of the properties map.
-     *                     If <code>false</code> the href will not be altered and will be kept as-is.
-     * @return a resource instance corresponding to the specified clazz.
-     * @version 1.0.RC9
-     */
-    public <T extends Resource> T instantiate(Class<T> clazz, Map<String, Object> properties, QueryString qs, boolean hrefFragment) {
+    @Override
+    public <T extends Resource> T instantiate(Class<T> clazz, Map<String, Object> properties, boolean hrefFragment) {
         if (hrefFragment) {
             Assert.hasText((String) properties.get("href"), "when hrefFragment is set to true the properties map must contain an href key.");
             String hrefValue = (String) properties.get("href");
             hrefValue = qualify(hrefValue);
             properties.put("href", hrefValue);
         }
-        return this.instantiate(clazz, properties, qs);
+        return this.instantiate(clazz, properties);
     }
 
     /* =====================================================================

--- a/impl/src/main/java/com/stormpath/sdk/impl/ds/InternalDataStore.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/ds/InternalDataStore.java
@@ -36,6 +36,21 @@ public interface InternalDataStore extends DataStore {
 
     <T extends Resource> T instantiate(Class<T> clazz, Map<String,Object> properties);
 
+    /**
+     * Instantiates and returns a new instance of the specified Resource type. The instance is merely instantiated and
+     * is not saved/synchronized with the server in any way. This operation allows
+     * the <code>href</code> to be a fragment, where the <code>baseUrl</code> can be missing and will be added automatically.
+     *
+     * @param clazz the Resource class to instantiate.
+     * @param <T>   the Resource sub-type
+     * @param properties the properties the instantiated resource will have
+     * @param hrefFragment when <code>true</code>, the baseUrl will be appended to the value found in the href key of the properties map.
+     *                     If <code>false</code> the href will not be altered and will be kept as-is.
+     * @return a resource instance corresponding to the specified clazz.
+     * @since 1.0.RC9
+     */
+    public <T extends Resource> T instantiate(Class<T> clazz, Map<String, Object> properties, boolean hrefFragment);
+
     <T extends Resource> T create(String parentHref, T resource);
 
     <T extends Resource> T create(String parentHref, T resource, Options options);

--- a/impl/src/main/java/com/stormpath/sdk/impl/idsite/DefaultIdSiteUrlBuilder.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/idsite/DefaultIdSiteUrlBuilder.java
@@ -141,7 +141,7 @@ public class DefaultIdSiteUrlBuilder implements IdSiteUrlBuilder {
      * Fix for https://github.com/stormpath/stormpath-sdk-java/issues/184.
      * Base URL for IDSite is constructed from the applicationHref received in the constructor.
      *
-     * @version 1.0.RC4.2
+     * @since 1.0.RC4.2
      */
     protected String getBaseUrl(String href) {
 

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
@@ -44,8 +44,8 @@ public class DefaultAccessToken extends AbstractBaseOauth2Token implements Acces
      * @since 1.0.RC8.3
      */
     private void ensureAccessToken() {
-        try {
-            if(isMaterialized()) {
+        if(isMaterialized()) {
+            try {
                 Claims claims = Jwts.parser()
                         .setSigningKey(getDataStore().getApiKey().getSecret().getBytes("UTF-8"))
                         .parseClaimsJws(getString(JWT)).getBody();
@@ -53,9 +53,14 @@ public class DefaultAccessToken extends AbstractBaseOauth2Token implements Acces
                 // token *must* have an rti claim to be an access_token
                 // otherwise, it may be a refresh_token trying to be passed off as an access_token
                 Assert.isTrue(Strings.hasText((String) claims.get("rti")));
+            } catch (Exception e) {
+                throw new JwtException("JWT failed validation; it cannot be trusted.");
             }
-        } catch (Exception e) {
-            throw new JwtException("JWT failed validation; it cannot be trusted.");
+        } else {
+            String href = getStringProperty(HREF_PROP_NAME);
+            if (href != null) {
+                Assert.isTrue(href.contains("/accessTokens/"), "href does not belong to an access token.");
+            }
         }
     }
 }

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
@@ -45,13 +45,15 @@ public class DefaultAccessToken extends AbstractBaseOauth2Token implements Acces
      */
     private void ensureAccessToken() {
         try {
-            Claims claims = Jwts.parser()
-                .setSigningKey(getDataStore().getApiKey().getSecret().getBytes("UTF-8"))
-                .parseClaimsJws(getString(JWT)).getBody();
+            if(isMaterialized()) {
+                Claims claims = Jwts.parser()
+                        .setSigningKey(getDataStore().getApiKey().getSecret().getBytes("UTF-8"))
+                        .parseClaimsJws(getString(JWT)).getBody();
 
-            // token *must* have an rti claim to be an access_token
-            // otherwise, it may be a refresh_token trying to be passed off as an access_token
-            Assert.isTrue(Strings.hasText((String) claims.get("rti")));
+                // token *must* have an rti claim to be an access_token
+                // otherwise, it may be a refresh_token trying to be passed off as an access_token
+                Assert.isTrue(Strings.hasText((String) claims.get("rti")));
+            }
         } catch (Exception e) {
             throw new JwtException("JWT failed validation; it cannot be trusted.");
         }


### PR DESCRIPTION
Resolves #479 

We are calling the backend twice per token in order to revoke it: 1) get the resource, 2) delete it.

This PR instantiates the Resource without contacting the backend and then issues the delete operation which does contact the backend.