### PR TITLE
Expose expandedJwt in AccessToken and RefreshToken resources

### DIFF
--- a/api/src/main/java/com/stormpath/sdk/oauth/BaseOauth2Token.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/BaseOauth2Token.java
@@ -21,6 +21,8 @@ import com.stormpath.sdk.resource.Deletable;
 import com.stormpath.sdk.resource.Resource;
 import com.stormpath.sdk.tenant.Tenant;
 
+import java.util.Map;
+
 /**
  * This is a base interface for those methods that Stormpath
  * {@link AccessToken}s and {@link RefreshToken}s have in common.
@@ -59,5 +61,14 @@ public interface BaseOauth2Token extends Resource, Deletable {
      * @return the {@link Tenant} this {@link AccessToken} belongs to.
      */
     Tenant getTenant();
+
+    /**
+     * Returns the expanded (un-compacted) properties of this {@link AccessToken}'s JWT.
+     *
+     * @return the expanded (un-compacted) properties of this {@link AccessToken}'s JWT.
+     *
+     * @version 1.0.RC9
+     */
+    Map<String, Object> getExpandedJwt();
 
 }

--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
@@ -29,10 +29,8 @@ import com.stormpath.sdk.application.ApplicationAccountStoreMapping
 import com.stormpath.sdk.application.ApplicationAccountStoreMappingList
 import com.stormpath.sdk.application.Applications
 import com.stormpath.sdk.directory.AccountStore
-import com.stormpath.sdk.lang.Assert
 import com.stormpath.sdk.oauth.AccessToken
 import com.stormpath.sdk.oauth.Authenticators
-import com.stormpath.sdk.oauth.IdSiteAuthenticationRequest
 import com.stormpath.sdk.oauth.JwtAuthenticationResult
 import com.stormpath.sdk.oauth.Oauth2Requests
 import com.stormpath.sdk.oauth.JwtAuthenticationRequest
@@ -64,6 +62,7 @@ import com.stormpath.sdk.resource.ResourceException
 import com.stormpath.sdk.saml.SamlPolicy
 import com.stormpath.sdk.saml.SamlServiceProvider
 import com.stormpath.sdk.tenant.Tenant
+import io.jsonwebtoken.SignatureAlgorithm
 import org.apache.commons.codec.binary.Base64
 import org.testng.annotations.Test
 
@@ -1430,6 +1429,10 @@ class ApplicationIT extends ClientIT {
         assertNotNull result.accessTokenHref
         assertEquals result.getAccessToken().getAccount().getEmail(), email
         assertEquals result.getAccessToken().getApplication().getHref(), app.href
+        assertEquals(((Map)result.getAccessToken().getExpandedJwt().get("claims")).get("iss"), app.getHref())
+        assertNotNull(((Map)result.getAccessToken().getExpandedJwt().get("claims")).get("rti"))
+        assertEquals(((Map)result.getAccessToken().getExpandedJwt().get("header")).get("alg"), SignatureAlgorithm.HS256.toString())
+        assertNotNull(result.getAccessToken().getExpandedJwt().get("signature"))
 
         RefreshGrantRequest request = Oauth2Requests.REFRESH_GRANT_REQUEST.builder().setRefreshToken(result.getRefreshTokenString()).build();
         result = Authenticators.REFRESH_GRANT_AUTHENTICATOR.forApplication(app).authenticate(request)
@@ -1439,6 +1442,10 @@ class ApplicationIT extends ClientIT {
         assertNotNull result.accessTokenHref
         assertEquals result.getRefreshToken().getAccount().getEmail(), email
         assertEquals result.getRefreshToken().getApplication().getHref(), app.href
+        assertEquals(((Map)result.getRefreshToken().getExpandedJwt().get("claims")).get("sub"), account.getHref())
+        assertNull(((Map)result.getRefreshToken().getExpandedJwt().get("claims")).get("rti"))
+        assertEquals(((Map)result.getRefreshToken().getExpandedJwt().get("header")).get("alg"), SignatureAlgorithm.HS256.toString())
+        assertNotNull(result.getRefreshToken().getExpandedJwt().get("signature"))
     }
 
     /* @since 1.0.RC7 */

--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
@@ -1438,8 +1438,11 @@ class ApplicationIT extends ClientIT {
         result = Authenticators.REFRESH_GRANT_AUTHENTICATOR.forApplication(app).authenticate(request)
 
         assertNotNull result
-        assertNotNull result.accessTokenString
-        assertNotNull result.accessTokenHref
+        assertTrue result.accessTokenString.size() > 1
+        assertTrue result.refreshTokenString.size() > 1
+        assertFalse(result.accessTokenString.equals(result.refreshTokenString))
+        assertTrue(result.getAccessToken().getHref().contains("/accessTokens/"))
+        assertTrue(result.getRefreshToken().getHref().contains("/refreshTokens/"))
         assertEquals result.getRefreshToken().getAccount().getEmail(), email
         assertEquals result.getRefreshToken().getApplication().getHref(), app.href
         assertEquals(((Map)result.getRefreshToken().getExpandedJwt().get("claims")).get("sub"), account.getHref())

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/AbstractBaseOauth2Token.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/AbstractBaseOauth2Token.java
@@ -5,6 +5,7 @@ import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.impl.ds.InternalDataStore;
 import com.stormpath.sdk.impl.resource.AbstractInstanceResource;
 import com.stormpath.sdk.impl.resource.DateProperty;
+import com.stormpath.sdk.impl.resource.MapProperty;
 import com.stormpath.sdk.impl.resource.Property;
 import com.stormpath.sdk.impl.resource.ResourceReference;
 import com.stormpath.sdk.impl.resource.StringProperty;
@@ -19,6 +20,7 @@ import java.util.Map;
  */
 public abstract class AbstractBaseOauth2Token extends AbstractInstanceResource implements BaseOauth2Token {
 
+    // SIMPLE PROPERTIES
     static final String ACCOUNT_PROP_NAME = "account";
     static final String APPLICATION_PROP_NAME = "application";
     static final String JWT_PROP_NAME = "jwt";
@@ -26,6 +28,7 @@ public abstract class AbstractBaseOauth2Token extends AbstractInstanceResource i
 
     static final StringProperty JWT = new StringProperty(JWT_PROP_NAME);
     static final DateProperty CREATED_AT = new DateProperty("created_at");
+    static final MapProperty EXPANDED_JWT = new MapProperty("expandedJwt");
 
     // INSTANCE RESOURCE REFERENCES:
     static final ResourceReference<Account> ACCOUNT = new ResourceReference<Account>(ACCOUNT_PROP_NAME, Account.class);
@@ -75,6 +78,11 @@ public abstract class AbstractBaseOauth2Token extends AbstractInstanceResource i
     @Override
     public void delete() {
         getDataStore().delete(this);
+    }
+
+    @Override
+    public Map<String, Object> getExpandedJwt() {
+        return getMap(EXPANDED_JWT);
     }
 
 }

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultGrantAuthenticationToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultGrantAuthenticationToken.java
@@ -81,8 +81,8 @@ public class DefaultGrantAuthenticationToken extends AbstractInstanceResource im
 
     public RefreshToken getAsRefreshToken(){
         Map<String, Object> props = new LinkedHashMap<String, Object>(1);
-        String accessTokenID = (String)((Map)this.getAsAccessToken().getExpandedJwt().get("claims")).get("rti");
-        props.put("href", "/refreshTokens/" + accessTokenID);
+        String refreshTokenID = (String)((Map)this.getAsAccessToken().getExpandedJwt().get("claims")).get("rti");
+        props.put("href", "/refreshTokens/" + refreshTokenID);
         return getDataStore().instantiate(RefreshToken.class, props);
     }
 }

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultGrantAuthenticationToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultGrantAuthenticationToken.java
@@ -81,7 +81,8 @@ public class DefaultGrantAuthenticationToken extends AbstractInstanceResource im
 
     public RefreshToken getAsRefreshToken(){
         Map<String, Object> props = new LinkedHashMap<String, Object>(1);
-        props.put("href", this.getAccessTokenHref());
+        String accessTokenID = (String)((Map)this.getAsAccessToken().getExpandedJwt().get("claims")).get("rti");
+        props.put("href", "/refreshTokens/" + accessTokenID);
         return getDataStore().instantiate(RefreshToken.class, props);
     }
 }


### PR DESCRIPTION
resolves #485 

The Backend was returning an `expandedJwt` property for both AccessToken and RefreshToken. We were not exposing that in our API.

I also discovered a bug where the `RefreshToken` was having the HREF of its associated `AccessToken` rather than the correct `RefreshToken` one.