### PR TITLE
Coverage jacoco coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - STORMPATH_API_KEY_ID_TWO_APP=VN3N09Z6BUE7QWL4RYX4FID3X
   - secure: ZAs6XDgRX1YIZAKf0IcR6DlfQtGLKJS5fyTOextZsRW3MCwu7WTBe5v6dAS6xoLqZ0iEkICMdIRhs+6DQEW6rju/W39mjxe8HJEcMNI+wZyW+rZ+j7NmPkjovMO+XbiR0aVVvn7ZGjWEKdozCTBVtJSLd8YVHh6Ey+yxOdDoc1A=
   - secure: GD3ZS7+oXVngRZdxPAjDbLNSjHNvKQ8IBXlo+DyDQ1kYAfyxSHD6eY0mW2SuqpUZ67e9XKhXd5z0VLgGAtn7JLco+56jyuBQKk8ak+KLctmUKIyFPNk6/11q/+vGIMEeKnmA5lI6UE+rcJOoSTtsubxbQkZE/mlZ79bckcx9W70=
+  - secure: XaSpWM+WSiXI3HnUL2WV3JD4Sl+dlqv37lvI+TFM0ns5UhCPylSE39h62ioJB85xLJKSpL0EZ/oVXPBdjY7ue3iaTbDtfiwpElCKyuizkzFHxy+3kGwpmq3SjVMaW57D86ubdpgkdzaHQr4aVzB+FhXl0Sdk6s20wGU+Sg/mqB4=
 before_install:
 - openssl aes-256-cbc -K $encrypted_da634cfd642b_key -iv $encrypted_da634cfd642b_iv
   -in deployKey_stormpath_github_io_id_rsa.enc -out ~/.ssh/id_rsa -d
@@ -35,6 +36,7 @@ notifications:
     on_failure: always
     rooms:
       secure: WXJLZTnleKQd5DIfdPSNYk4ZT7bssV9esdaacZjwb9sdKLZAQ+ujL97uuVK4oDMbua9XJxYTsKK45QQp56+PgJc4KG0Regvs/e7NtoxahrNnpsHCob4+Hc2MSmFfJgsdAQ9dFemNZ3BQ2ec1gO6SToYk+7pwMPScUYnmAOrsHjU=
-    template:
-      '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} (<a href="%{build_url}">Details</a>/<a href="%{compare_url}">Change view</a>)' 
+    template: '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}):
+      %{message} (<a href="%{build_url}">Details</a>/<a href="%{compare_url}">Change
+      view</a>)'
     format: html

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
 - test -z "$BUILD_DOCS" || ./build_docs.sh
 after_success:
 - test -z "$BUILD_DOCS" || test -z "$IS_RELEASE" || ./publish_docs.sh
+- mvn jacoco:report coveralls:jacoco
 notifications:
   hipchat:
     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 - export IS_RELEASE="$([ ${RELEASE_VERSION/SNAPSHOT} == $RELEASE_VERSION ] && [ $TRAVIS_BRANCH
   == 'master' ] && echo 'true')"
 - export BUILD_DOCS="$([ $TRAVIS_JDK_VERSION == 'oraclejdk8' ] && echo 'true')"
-- export COVERALLS_REPORT="$([ $TRAVIS_JDK_VERSION == 'openjdk6' ] && echo 'true')"
+- export COVERALLS_REPORT="$([ $TRAVIS_JDK_VERSION == 'openjdk7' ] && echo 'true')"
 install:
 - test -z "$BUILD_DOCS" || pip -q install --user sphinx
 - echo "No need to run mvn install -DskipTests then mvn install.  Running mvn install."

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 - test -z "$BUILD_DOCS" || ./build_docs.sh
 after_success:
 - test -z "$BUILD_DOCS" || test -z "$IS_RELEASE" || ./publish_docs.sh
-- mvn clean test jacoco:report coveralls:report
+- mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify coveralls:report
 notifications:
   hipchat:
     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 - test -z "$BUILD_DOCS" || ./build_docs.sh
 after_success:
 - test -z "$BUILD_DOCS" || test -z "$IS_RELEASE" || ./publish_docs.sh
-- mvn jacoco:report coveralls:jacoco
+- mvn clean test jacoco:report coveralls:report
 notifications:
   hipchat:
     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ before_install:
   -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)')"
 - export IS_RELEASE="$([ ${RELEASE_VERSION/SNAPSHOT} == $RELEASE_VERSION ] && [ $TRAVIS_BRANCH
   == 'master' ] && echo 'true')"
-- export BUILD_DOCS="$([ $TRAVIS_JDK_VERSION == 'oraclejdk8' ] && echo 'true')"
-- export COVERALLS_REPORT="$([ $TRAVIS_JDK_VERSION == 'openjdk7' ] && echo 'true')"
+- export BUILD_DOCS="$([ $TRAVIS_JDK_VERSION == 'oraclejdk7' ] && echo 'true')"
+- export COVERALLS_REPORT="$([ $TRAVIS_JDK_VERSION == 'oraclejdk8' ] && echo 'true')"
 install:
 - test -z "$BUILD_DOCS" || pip -q install --user sphinx
 - echo "No need to run mvn install -DskipTests then mvn install.  Running mvn install."

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 - export IS_RELEASE="$([ ${RELEASE_VERSION/SNAPSHOT} == $RELEASE_VERSION ] && [ $TRAVIS_BRANCH
   == 'master' ] && echo 'true')"
 - export BUILD_DOCS="$([ $TRAVIS_JDK_VERSION == 'oraclejdk8' ] && echo 'true')"
+- export COVERALLS_REPORT="$([ $TRAVIS_JDK_VERSION == 'openjdk6' ] && echo 'true')"
 install:
 - test -z "$BUILD_DOCS" || pip -q install --user sphinx
 - echo "No need to run mvn install -DskipTests then mvn install.  Running mvn install."
@@ -29,7 +30,7 @@ script:
 - test -z "$BUILD_DOCS" || ./build_docs.sh
 after_success:
 - test -z "$BUILD_DOCS" || test -z "$IS_RELEASE" || ./publish_docs.sh
-- mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify coveralls:report
+- test -z "$COVERALLS_REPORT" || mvn coveralls:report
 notifications:
   hipchat:
     on_success: always

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://api.travis-ci.org/stormpath/stormpath-sdk-java.png?branch=master)](https://travis-ci.org/stormpath/stormpath-sdk-java)
-[![Coverage Status](https://coveralls.io/repos/github/stormpath/stormpath-sdk-java/badge.svg?branch=master)](https://coveralls.io/github/stormpath/stormpath-sdk-java?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/stormpath/stormpath-sdk-java/badge.svg?branch=coverage_jacoco_coveralls)](https://coveralls.io/github/stormpath/stormpath-sdk-java?branch=coverage_jacoco_coveralls)
 # Stormpath Java SDK #
 
 *An advanced, reliable and easy-to-use user management API, built by Java security experts*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://api.travis-ci.org/stormpath/stormpath-sdk-java.png?branch=master)](https://travis-ci.org/stormpath/stormpath-sdk-java)
-[![Coverage Status](https://coveralls.io/repos/github/stormpath/stormpath-sdk-java/badge.svg?branch=coverage_jacoco_coveralls)](https://coveralls.io/github/stormpath/stormpath-sdk-java?branch=coverage_jacoco_coveralls)
 # Stormpath Java SDK #
 
 *An advanced, reliable and easy-to-use user management API, built by Java security experts*

--- a/README.md
+++ b/README.md
@@ -88,3 +88,4 @@ Copyright &copy; 2013-2015 Stormpath, Inc. and contributors.
 This project is open-source via the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).
 
 For all additional information, please see the full [Project Documentation](http://docs.stormpath.com/java/product-guide/).
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build Status](https://api.travis-ci.org/stormpath/stormpath-sdk-java.png?branch=master)](https://travis-ci.org/stormpath/stormpath-sdk-java)
-[![Coverage Status](https://coveralls.io/repos/stormpath/stormpath-sdk-java/badge.svg?branch=master&service=github)](https://coveralls.io/github/stormpath/stormpath-sdk-java?branch=master)
-
+[![Coverage Status](https://coveralls.io/repos/github/stormpath/stormpath-sdk-java/badge.svg?branch=master)](https://coveralls.io/github/stormpath/stormpath-sdk-java?branch=master)
 # Stormpath Java SDK #
 
 *An advanced, reliable and easy-to-use user management API, built by Java security experts*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://api.travis-ci.org/stormpath/stormpath-sdk-java.png?branch=master)](https://travis-ci.org/stormpath/stormpath-sdk-java)
+[![Coverage Status](https://coveralls.io/repos/stormpath/stormpath-sdk-java/badge.svg?branch=master&service=github)](https://coveralls.io/github/stormpath/stormpath-sdk-java?branch=master)
 
 # Stormpath Java SDK #
 

--- a/extensions/oauth/src/main/java/com/stormpath/sdk/impl/oauth/authc/AccessTokenAuthenticationRequest.java
+++ b/extensions/oauth/src/main/java/com/stormpath/sdk/impl/oauth/authc/AccessTokenAuthenticationRequest.java
@@ -122,6 +122,6 @@ public class AccessTokenAuthenticationRequest extends OAuthTokenRequest implemen
     /* @since 1.0.RC5 */
     @Override
     public AuthenticationOptions getResponseOptions() {
-        throw new UnsupportedOperationException(getClass().getName() + " .getResponseOptions() is not supported.");
+        throw new UnsupportedOperationException(getClass().getName() + ".getResponseOptions() is not supported.");
     }
 }

--- a/extensions/oauth/src/test/groovy/com/stormpath/sdk/impl/oauth/AccessTokenAuthenticationRequestTest.groovy
+++ b/extensions/oauth/src/test/groovy/com/stormpath/sdk/impl/oauth/AccessTokenAuthenticationRequestTest.groovy
@@ -15,11 +15,12 @@ import static org.testng.Assert.fail
 
 class AccessTokenAuthenticationRequestTest {
 
-    def httpServletRequest = createMock(HttpRequest.class)
+    def httpRequest = createMock(HttpRequest.class)
     AccessTokenAuthenticationRequest accessTokenAuthenticationRequest
 
     @BeforeTest
     public void setup() {
+
         def params = [
                 grant_type: ["password"] as String[],
                 username: ["blarg@blargity.com"] as String[],
@@ -28,18 +29,18 @@ class AccessTokenAuthenticationRequestTest {
                 client_secret: ["secret"] as String[]
         ]
 
-        expect(httpServletRequest.getParameters())
+        expect(httpRequest.getParameters())
                 .andReturn(params).times(6)
-        expect(httpServletRequest.getMethod())
+        expect(httpRequest.getMethod())
                 .andReturn(HttpMethod.POST)
-        expect(httpServletRequest.getHeader("Content-Type"))
+        expect(httpRequest.getHeader("Content-Type"))
                 .andReturn("application/x-www-form-urlencoded")
-        expect(httpServletRequest.getHeader("Authorization"))
-                .andReturn("Basic " + new BASE64Encoder().encode("a:b".bytes)).times(2)
+        expect(httpRequest.getHeader("Authorization"))
+                .andReturn("Basic " + new BASE64Encoder().encode("id:secret".bytes)).times(2)
 
-        replay httpServletRequest
+        replay httpRequest
 
-        accessTokenAuthenticationRequest = new AccessTokenAuthenticationRequest(httpServletRequest)
+        accessTokenAuthenticationRequest = new AccessTokenAuthenticationRequest(httpRequest)
     }
 
     @Test
@@ -49,7 +50,7 @@ class AccessTokenAuthenticationRequestTest {
             accessTokenAuthenticationRequest.getHost()
             fail("shouldn't be here")
         } catch (UnsupportedOperationException e) {
-            assertEquals(e.getMessage(), "getHost() method hasn't been implemented.")
+            assertEquals e.getMessage(), "getHost() method hasn't been implemented."
         }
     }
 
@@ -60,7 +61,7 @@ class AccessTokenAuthenticationRequestTest {
             accessTokenAuthenticationRequest.clear()
             fail("shouldn't be here")
         } catch (UnsupportedOperationException e) {
-            assertEquals(e.getMessage(), "clear() method hasn't been implemented.")
+            assertEquals e.getMessage(), "clear() method hasn't been implemented."
         }
     }
 
@@ -71,7 +72,60 @@ class AccessTokenAuthenticationRequestTest {
             accessTokenAuthenticationRequest.getResponseOptions()
             fail("shouldn't be here")
         } catch (UnsupportedOperationException e) {
-            assertEquals(e.getMessage(), "com.stormpath.sdk.impl.oauth.authc.AccessTokenAuthenticationRequest.getResponseOptions() is not supported.")
+            assertEquals e.getMessage(), "com.stormpath.sdk.impl.oauth.authc.AccessTokenAuthenticationRequest.getResponseOptions() is not supported."
         }
+    }
+
+    @Test
+    public void testGetAccountStore() {
+
+        try {
+            accessTokenAuthenticationRequest.getAccountStore()
+            fail("shouldn't be here")
+        } catch (UnsupportedOperationException e) {
+            assertEquals e.getMessage(), "getAccountStore() method hasn't been implemented."
+        }
+    }
+
+    @Test
+    public void testDefaultTtl() {
+
+        assertEquals accessTokenAuthenticationRequest.getTtl(), AccessTokenAuthenticationRequest.DEFAULT_TTL
+    }
+
+    @Test
+    public void testDefaultScopeFactory() {
+
+        assertEquals accessTokenAuthenticationRequest.getScopeFactory(), null
+    }
+
+    @Test
+    public void testDefaultHasScopeFactory() {
+
+        assertEquals accessTokenAuthenticationRequest.hasScopeFactory(), false
+    }
+
+    @Test
+    public void testGetClentId() {
+
+        assertEquals accessTokenAuthenticationRequest.getClientId(), "id"
+    }
+
+    @Test
+    public void testGetClientSecret() {
+
+        assertEquals accessTokenAuthenticationRequest.getClientSecret(), "secret"
+    }
+
+    @Test
+    public void testGetPrincipals() {
+
+        assertEquals accessTokenAuthenticationRequest.getPrincipals(), "id"
+    }
+
+    @Test
+    public void testGetCredentials() {
+
+        assertEquals accessTokenAuthenticationRequest.getCredentials(), "secret"
     }
 }

--- a/extensions/oauth/src/test/groovy/com/stormpath/sdk/impl/oauth/AccessTokenAuthenticationRequestTest.groovy
+++ b/extensions/oauth/src/test/groovy/com/stormpath/sdk/impl/oauth/AccessTokenAuthenticationRequestTest.groovy
@@ -1,0 +1,77 @@
+package com.stormpath.sdk.impl.oauth
+
+import com.stormpath.sdk.http.HttpMethod
+import com.stormpath.sdk.http.HttpRequest
+import com.stormpath.sdk.impl.oauth.authc.AccessTokenAuthenticationRequest
+import org.testng.annotations.BeforeTest
+import org.testng.annotations.Test
+import sun.misc.BASE64Encoder
+
+import static org.easymock.EasyMock.createMock
+import static org.easymock.EasyMock.expect
+import static org.easymock.EasyMock.replay
+import static org.testng.Assert.assertEquals
+import static org.testng.Assert.fail
+
+class AccessTokenAuthenticationRequestTest {
+
+    def httpServletRequest = createMock(HttpRequest.class)
+    AccessTokenAuthenticationRequest accessTokenAuthenticationRequest
+
+    @BeforeTest
+    public void setup() {
+        def params = [
+                grant_type: ["password"] as String[],
+                username: ["blarg@blargity.com"] as String[],
+                password: ["password"] as String[],
+                client_id: ["id"] as String[],
+                client_secret: ["secret"] as String[]
+        ]
+
+        expect(httpServletRequest.getParameters())
+                .andReturn(params).times(6)
+        expect(httpServletRequest.getMethod())
+                .andReturn(HttpMethod.POST)
+        expect(httpServletRequest.getHeader("Content-Type"))
+                .andReturn("application/x-www-form-urlencoded")
+        expect(httpServletRequest.getHeader("Authorization"))
+                .andReturn("Basic " + new BASE64Encoder().encode("a:b".bytes)).times(2)
+
+        replay httpServletRequest
+
+        accessTokenAuthenticationRequest = new AccessTokenAuthenticationRequest(httpServletRequest)
+    }
+
+    @Test
+    public void testGetHost() {
+
+        try {
+            accessTokenAuthenticationRequest.getHost()
+            fail("shouldn't be here")
+        } catch (UnsupportedOperationException e) {
+            assertEquals(e.getMessage(), "getHost() method hasn't been implemented.")
+        }
+    }
+
+    @Test
+    public void testClear() {
+
+        try {
+            accessTokenAuthenticationRequest.clear()
+            fail("shouldn't be here")
+        } catch (UnsupportedOperationException e) {
+            assertEquals(e.getMessage(), "clear() method hasn't been implemented.")
+        }
+    }
+
+    @Test
+    public void testGetResponseOptions() {
+
+        try {
+            accessTokenAuthenticationRequest.getResponseOptions()
+            fail("shouldn't be here")
+        } catch (UnsupportedOperationException e) {
+            assertEquals(e.getMessage(), "com.stormpath.sdk.impl.oauth.authc.AccessTokenAuthenticationRequest.getResponseOptions() is not supported.")
+        }
+    }
+}

--- a/jacoco-multi-coverage/pom.xml
+++ b/jacoco-multi-coverage/pom.xml
@@ -1,0 +1,264 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.stormpath.sdk</groupId>
+        <artifactId>stormpath-sdk-root</artifactId>
+        <version>1.0.RC9-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>jacoco-multi-coverage</artifactId>
+
+    <properties>
+
+        <!-- base -->
+        <base.api>../api</base.api>
+        <base.impl>../impl</base.impl>
+        <base.extensions>../extensions</base.extensions>
+        <base.extensions.spring>${base.extensions}/spring</base.extensions.spring>
+        <base.extensions.spring.boot>${base.extensions.spring}/boot</base.extensions.spring.boot>
+
+        <base.extensions.hazelcast>${base.extensions}/hazelcast</base.extensions.hazelcast>
+        <base.extensions.httpclient>${base.extensions}/httpclient</base.extensions.httpclient>
+        <base.extensions.servlet>${base.extensions}/servlet</base.extensions.servlet>
+
+        <base.stormpath-spring>${base.extensions.spring}/stormpath-spring</base.stormpath-spring>
+        <base.stormpath-spring-webmvc>${base.extensions.spring}/stormpath-spring-webmvc</base.stormpath-spring-webmvc>
+        <base.stormpath-spring-security>${base.extensions.spring}/stormpath-spring-security</base.stormpath-spring-security>
+        <base.stormpath-spring-security-webmvc>${base.extensions.spring}/stormpath-spring-security-webmvc</base.stormpath-spring-security-webmvc>
+
+        <base.stormpath-spring-boot-starter>${base.extensions.spring.boot}/stormpath-spring-boot-starter</base.stormpath-spring-boot-starter>
+        <base.stormpath-webmvc-spring-boot-starter>${base.extensions.spring.boot}/stormpath-webmvc-spring-boot-starter</base.stormpath-webmvc-spring-boot-starter>
+        <base.stormpath-spring-security-spring-boot-starter>${base.extensions.spring.boot}/stormpath-spring-security-spring-boot-starter</base.stormpath-spring-security-spring-boot-starter>
+        <base.stormpath-spring-security-webmvc-spring-boot-starter>${base.extensions.spring.boot}/stormpath-spring-security-webmvc-spring-boot-starter</base.stormpath-spring-security-webmvc-spring-boot-starter>
+
+        <!-- build -->
+        <build.api>${base.api}/target</build.api>
+        <build.impl>${base.impl}/target</build.impl>
+        <build.hazelcast>${base.extensions.hazelcast}/target</build.hazelcast>
+        <build.httpclient>${base.extensions.httpclient}/target</build.httpclient>
+        <build.servlet>${base.extensions.servlet}/target</build.servlet>
+        <build.stormpath-spring>${base.stormpath-spring}/target</build.stormpath-spring>
+        <build.stormpath-spring-webmvc>${base.stormpath-spring-webmvc}/target</build.stormpath-spring-webmvc>
+        <build.stormpath-spring-security>${base.stormpath-spring-security}/target</build.stormpath-spring-security>
+        <build.stormpath-spring-security-webmvc>${base.stormpath-spring-security-webmvc}/target</build.stormpath-spring-security-webmvc>
+        <build.stormpath-spring-boot-starter>${base.stormpath-spring-boot-starter}/target</build.stormpath-spring-boot-starter>
+        <build.stormpath-webmvc-spring-boot-starter>${base.stormpath-webmvc-spring-boot-starter}/target</build.stormpath-webmvc-spring-boot-starter>
+        <build.stormpath-spring-security-spring-boot-starter>${base.stormpath-spring-security-spring-boot-starter}/target</build.stormpath-spring-security-spring-boot-starter>
+        <build.stormpath-spring-security-webmvc-spring-boot-starter>${base.stormpath-spring-security-webmvc-spring-boot-starter}/target</build.stormpath-spring-security-webmvc-spring-boot-starter>
+
+        <!-- classes -->
+        <classes.api>${build.api}/classes</classes.api>
+        <classes.impl>${build.impl}/classes</classes.impl>
+        <classes.extensions.hazelcast>${build.hazelcast}/classes</classes.extensions.hazelcast>
+        <classes.extensions.httpclient>${build.httpclient}/classes</classes.extensions.httpclient>
+        <classes.extensions.servlet>${build.servlet}/classes</classes.extensions.servlet>
+        <classes.stormpath-spring>${build.stormpath-spring}/classes</classes.stormpath-spring>
+        <classes.stormpath-spring-webmvc>${build.stormpath-spring-webmvc}/classes</classes.stormpath-spring-webmvc>
+        <classes.stormpath-spring-security>${build.stormpath-spring-security}/classes</classes.stormpath-spring-security>
+        <classes.stormpath-spring-security-webmvc>${build.stormpath-spring-security-webmvc}/classes</classes.stormpath-spring-security-webmvc>
+        <classes.stormpath-spring-boot-starter>${build.stormpath-spring-boot-starter}/classes</classes.stormpath-spring-boot-starter>
+        <classes.stormpath-webmvc-spring-boot-starter>${build.stormpath-webmvc-spring-boot-starter}/classes</classes.stormpath-webmvc-spring-boot-starter>
+        <classes.stormpath-spring-security-spring-boot-starter>${build.stormpath-spring-security-spring-boot-starter}/classes</classes.stormpath-spring-security-spring-boot-starter>
+        <classes.stormpath-spring-security-webmvc-spring-boot-starter>${build.stormpath-spring-security-webmvc-spring-boot-starter}/classes</classes.stormpath-spring-security-webmvc-spring-boot-starter>
+
+
+        <!-- sources -->
+        <sources.api>${base.api}/src/main/java</sources.api>
+        <sources.impl>${base.impl}/src/main/java</sources.impl>
+        <sources.extensions.hazelcast>${base.extensions.hazelcast}/src/main/java</sources.extensions.hazelcast>
+        <sources.extensions.httpclient>${base.extensions.httpclient}/src/main/java</sources.extensions.httpclient>
+        <sources.extensions.servlet>${base.extensions.servlet}/src/main/java</sources.extensions.servlet>
+        <sources.stormpath-spring>${base.stormpath-spring}/src/main/java</sources.stormpath-spring>
+        <sources.stormpath-spring-webmvc>${base.stormpath-spring-webmvc}/src/main/java</sources.stormpath-spring-webmvc>
+        <sources.stormpath-spring-security>${base.stormpath-spring-security}/src/main/java</sources.stormpath-spring-security>
+        <sources.stormpath-spring-security-webmvc>${base.stormpath-spring-security-webmvc}/src/main/java</sources.stormpath-spring-security-webmvc>
+        <sources.stormpath-spring-boot-starter>${base.stormpath-spring-boot-starter}/src/main/java</sources.stormpath-spring-boot-starter>
+        <sources.stormpath-webmvc-spring-boot-starter>${base.stormpath-webmvc-spring-boot-starter}/src/main/java</sources.stormpath-webmvc-spring-boot-starter>
+        <sources.stormpath-spring-security-spring-boot-starter>${base.stormpath-spring-security-spring-boot-starter}/src/main/java</sources.stormpath-spring-security-spring-boot-starter>
+        <sources.stormpath-spring-security-webmvc-spring-boot-starter>${base.stormpath-spring-security-webmvc-spring-boot-starter}/src/main/java</sources.stormpath-spring-security-webmvc-spring-boot-starter>
+
+        <!-- generated-sources -->
+        <generated-sources.api>${build.api}/generated-sources</generated-sources.api>
+        <generated-sources.impl>${build.impl}/generated-sources</generated-sources.impl>
+        <generated-sources.extensions.hazelcast>${build.hazelcast}/generated-sources</generated-sources.extensions.hazelcast>
+        <generated-sources.extensions.httpclient>${build.httpclient}/generated-sources</generated-sources.extensions.httpclient>
+        <generated-sources.extensions.servlet>${build.servlet}/generated-sources</generated-sources.extensions.servlet>
+        <generated-sources.stormpath-spring>${build.stormpath-spring}/generated-sources</generated-sources.stormpath-spring>
+        <generated-sources.stormpath-spring-webmvc>${build.stormpath-spring-webmvc}/generated-sources</generated-sources.stormpath-spring-webmvc>
+        <generated-sources.stormpath-spring-security>${build.stormpath-spring-security}/generated-sources</generated-sources.stormpath-spring-security>
+        <generated-sources.stormpath-spring-security-webmvc>${build.stormpath-spring-security-webmvc}/generated-sources</generated-sources.stormpath-spring-security-webmvc>
+        <generated-sources.stormpath-spring-boot-starter>${build.stormpath-spring-boot-starter}/generated-sources</generated-sources.stormpath-spring-boot-starter>
+        <generated-sources.stormpath-webmvc-spring-boot-starter>${build.stormpath-webmvc-spring-boot-starter}/generated-sources</generated-sources.stormpath-webmvc-spring-boot-starter>
+        <generated-sources.stormpath-spring-security-spring-boot-starter>${build.stormpath-spring-security-spring-boot-starter}/generated-sources</generated-sources.stormpath-spring-security-spring-boot-starter>
+        <generated-sources.stormpath-spring-security-webmvc-spring-boot-starter>${build.stormpath-spring-security-webmvc-spring-boot-starter}/generated-sources</generated-sources.stormpath-spring-security-webmvc-spring-boot-starter>
+
+    </properties>
+
+
+    <build>
+        <plugins>
+            <!-- Dependencies -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!-- Copy the ant tasks jar. Needed for ts.jacoco.report-ant . -->
+                    <execution>
+                        <id>jacoco-dependency-ant</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jacoco</groupId>
+                                    <artifactId>org.jacoco.ant</artifactId>
+                                    <version>${jacoco.version}</version>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${basedir}/target/jacoco-jars</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+            <!-- Ant plugin. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <phase>${report-phase}</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- Execute an ant task within maven -->
+                                <echo message="Generating JaCoCo Reports" />
+                                <taskdef name="report" classname="org.jacoco.ant.ReportTask">
+                                    <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar" />
+                                </taskdef>
+                                <mkdir dir="${basedir}/target/coverage-report" />
+                                <report>
+                                    <executiondata>
+                                        <fileset dir="${build.api}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.impl}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.hazelcast}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.httpclient}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.servlet}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.stormpath-spring}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.stormpath-spring-webmvc}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.stormpath-spring-security}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.stormpath-spring-security-webmvc}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.stormpath-spring-boot-starter}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.stormpath-webmvc-spring-boot-starter}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.stormpath-spring-security-spring-boot-starter}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+                                        <fileset dir="${build.stormpath-spring-security-webmvc-spring-boot-starter}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
+
+                                    </executiondata>
+
+                                    <structure name="jacoco-multi Coverage Project">
+                                      <group name="jacoco-multi">
+                                        <classfiles>
+                                          <fileset dir="${classes.api}" />
+                                          <fileset dir="${classes.impl}" />
+                                          <fileset dir="${classes.extensions.hazelcast}" />
+                                          <fileset dir="${classes.extensions.httpclient}" />
+                                          <fileset dir="${classes.extensions.servlet}" />
+                                          <fileset dir="${classes.stormpath-spring}" />
+                                          <fileset dir="${classes.stormpath-spring-webmvc}" />
+                                          <fileset dir="${classes.stormpath-spring-security}" />
+                                          <fileset dir="${classes.stormpath-spring-security-webmvc}" />
+                                          <fileset dir="${classes.stormpath-spring-boot-starter}" />
+                                          <fileset dir="${classes.stormpath-webmvc-spring-boot-starter}" />
+                                          <fileset dir="${classes.stormpath-spring-security-spring-boot-starter}" />
+                                          <fileset dir="${classes.stormpath-spring-security-webmvc-spring-boot-starter}" />
+                                        </classfiles>
+                                        <sourcefiles encoding="UTF-8">
+                                          <fileset dir="${sources.api}" />
+                                          <fileset dir="${sources.impl}" />
+                                          <fileset dir="${sources.extensions.hazelcast}" />
+                                          <fileset dir="${sources.extensions.httpclient}" />
+                                          <fileset dir="${sources.extensions.servlet}" />
+                                          <fileset dir="${sources.stormpath-spring}" />
+                                          <fileset dir="${sources.stormpath-spring-webmvc}" />
+                                          <fileset dir="${sources.stormpath-spring-security}" />
+                                          <fileset dir="${sources.stormpath-spring-security-webmvc}" />
+                                          <fileset dir="${sources.stormpath-spring-boot-starter}" />
+                                          <fileset dir="${sources.stormpath-webmvc-spring-boot-starter}" />
+                                          <fileset dir="${sources.stormpath-spring-security-spring-boot-starter}" />
+                                          <fileset dir="${sources.stormpath-spring-security-webmvc-spring-boot-starter}" />
+
+                                          <fileset dir="${generated-sources.api}" />
+                                          <fileset dir="${generated-sources.impl}" />
+                                          <fileset dir="${generated-sources.extensions.hazelcast}" />
+                                          <fileset dir="${generated-sources.extensions.httpclient}" />
+                                          <fileset dir="${generated-sources.extensions.servlet}" />
+                                          <fileset dir="${generated-sources.stormpath-spring}" />
+                                          <fileset dir="${generated-sources.stormpath-spring-webmvc}" />
+                                          <fileset dir="${generated-sources.stormpath-spring-security}" />
+                                          <fileset dir="${generated-sources.stormpath-spring-security-webmvc}" />
+                                          <fileset dir="${generated-sources.stormpath-spring-boot-starter}" />
+                                          <fileset dir="${generated-sources.stormpath-webmvc-spring-boot-starter}" />
+                                          <fileset dir="${generated-sources.stormpath-spring-security-spring-boot-starter}" />
+                                          <fileset dir="${generated-sources.stormpath-spring-security-webmvc-spring-boot-starter}" />
+                                        </sourcefiles>
+                                      </group>
+                                    </structure>
+
+                                    <html destdir="${basedir}/target/coverage-report/html" />
+                                    <xml destfile="${basedir}/target/coverage-report/coverage-report.xml" />
+                                    <csv destfile="${basedir}/target/coverage-report/coverage-report.csv" />
+                                </report>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>org.jacoco.ant</artifactId>
+                        <version>${jacoco.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+        </plugins>
+    </build>
+
+
+</project>

--- a/jacoco-multi-coverage/pom.xml
+++ b/jacoco-multi-coverage/pom.xml
@@ -22,6 +22,7 @@
         <base.extensions.hazelcast>${base.extensions}/hazelcast</base.extensions.hazelcast>
         <base.extensions.httpclient>${base.extensions}/httpclient</base.extensions.httpclient>
         <base.extensions.servlet>${base.extensions}/servlet</base.extensions.servlet>
+        <base.extensions.oauth>${base.extensions}/oauth</base.extensions.oauth>
 
         <base.stormpath-spring>${base.extensions.spring}/stormpath-spring</base.stormpath-spring>
         <base.stormpath-spring-webmvc>${base.extensions.spring}/stormpath-spring-webmvc</base.stormpath-spring-webmvc>
@@ -39,6 +40,7 @@
         <build.hazelcast>${base.extensions.hazelcast}/target</build.hazelcast>
         <build.httpclient>${base.extensions.httpclient}/target</build.httpclient>
         <build.servlet>${base.extensions.servlet}/target</build.servlet>
+        <build.oauth>${base.extensions.oauth}/target</build.oauth>
         <build.stormpath-spring>${base.stormpath-spring}/target</build.stormpath-spring>
         <build.stormpath-spring-webmvc>${base.stormpath-spring-webmvc}/target</build.stormpath-spring-webmvc>
         <build.stormpath-spring-security>${base.stormpath-spring-security}/target</build.stormpath-spring-security>
@@ -54,6 +56,7 @@
         <classes.extensions.hazelcast>${build.hazelcast}/classes</classes.extensions.hazelcast>
         <classes.extensions.httpclient>${build.httpclient}/classes</classes.extensions.httpclient>
         <classes.extensions.servlet>${build.servlet}/classes</classes.extensions.servlet>
+        <classes.extensions.oauth>${build.oauth}/classes</classes.extensions.oauth>
         <classes.stormpath-spring>${build.stormpath-spring}/classes</classes.stormpath-spring>
         <classes.stormpath-spring-webmvc>${build.stormpath-spring-webmvc}/classes</classes.stormpath-spring-webmvc>
         <classes.stormpath-spring-security>${build.stormpath-spring-security}/classes</classes.stormpath-spring-security>
@@ -70,6 +73,7 @@
         <sources.extensions.hazelcast>${base.extensions.hazelcast}/src/main/java</sources.extensions.hazelcast>
         <sources.extensions.httpclient>${base.extensions.httpclient}/src/main/java</sources.extensions.httpclient>
         <sources.extensions.servlet>${base.extensions.servlet}/src/main/java</sources.extensions.servlet>
+        <sources.extensions.oauth>${base.extensions.oauth}/src/main/java</sources.extensions.oauth>
         <sources.stormpath-spring>${base.stormpath-spring}/src/main/java</sources.stormpath-spring>
         <sources.stormpath-spring-webmvc>${base.stormpath-spring-webmvc}/src/main/java</sources.stormpath-spring-webmvc>
         <sources.stormpath-spring-security>${base.stormpath-spring-security}/src/main/java</sources.stormpath-spring-security>
@@ -85,6 +89,7 @@
         <generated-sources.extensions.hazelcast>${build.hazelcast}/generated-sources</generated-sources.extensions.hazelcast>
         <generated-sources.extensions.httpclient>${build.httpclient}/generated-sources</generated-sources.extensions.httpclient>
         <generated-sources.extensions.servlet>${build.servlet}/generated-sources</generated-sources.extensions.servlet>
+        <generated-sources.extensions.oauth>${build.oauth}/generated-sources</generated-sources.extensions.oauth>
         <generated-sources.stormpath-spring>${build.stormpath-spring}/generated-sources</generated-sources.stormpath-spring>
         <generated-sources.stormpath-spring-webmvc>${build.stormpath-spring-webmvc}/generated-sources</generated-sources.stormpath-spring-webmvc>
         <generated-sources.stormpath-spring-security>${build.stormpath-spring-security}/generated-sources</generated-sources.stormpath-spring-security>
@@ -164,6 +169,9 @@
                                         <fileset dir="${build.servlet}">
                                             <include name="jacoco.exec" />
                                         </fileset>
+                                        <fileset dir="${build.oauth}">
+                                            <include name="jacoco.exec" />
+                                        </fileset>
                                         <fileset dir="${build.stormpath-spring}">
                                             <include name="jacoco.exec" />
                                         </fileset>
@@ -192,52 +200,55 @@
                                     </executiondata>
 
                                     <structure name="jacoco-multi Coverage Project">
-                                      <group name="jacoco-multi">
-                                        <classfiles>
-                                          <fileset dir="${classes.api}" />
-                                          <fileset dir="${classes.impl}" />
-                                          <fileset dir="${classes.extensions.hazelcast}" />
-                                          <fileset dir="${classes.extensions.httpclient}" />
-                                          <fileset dir="${classes.extensions.servlet}" />
-                                          <fileset dir="${classes.stormpath-spring}" />
-                                          <fileset dir="${classes.stormpath-spring-webmvc}" />
-                                          <fileset dir="${classes.stormpath-spring-security}" />
-                                          <fileset dir="${classes.stormpath-spring-security-webmvc}" />
-                                          <fileset dir="${classes.stormpath-spring-boot-starter}" />
-                                          <fileset dir="${classes.stormpath-webmvc-spring-boot-starter}" />
-                                          <fileset dir="${classes.stormpath-spring-security-spring-boot-starter}" />
-                                          <fileset dir="${classes.stormpath-spring-security-webmvc-spring-boot-starter}" />
-                                        </classfiles>
-                                        <sourcefiles encoding="UTF-8">
-                                          <fileset dir="${sources.api}" />
-                                          <fileset dir="${sources.impl}" />
-                                          <fileset dir="${sources.extensions.hazelcast}" />
-                                          <fileset dir="${sources.extensions.httpclient}" />
-                                          <fileset dir="${sources.extensions.servlet}" />
-                                          <fileset dir="${sources.stormpath-spring}" />
-                                          <fileset dir="${sources.stormpath-spring-webmvc}" />
-                                          <fileset dir="${sources.stormpath-spring-security}" />
-                                          <fileset dir="${sources.stormpath-spring-security-webmvc}" />
-                                          <fileset dir="${sources.stormpath-spring-boot-starter}" />
-                                          <fileset dir="${sources.stormpath-webmvc-spring-boot-starter}" />
-                                          <fileset dir="${sources.stormpath-spring-security-spring-boot-starter}" />
-                                          <fileset dir="${sources.stormpath-spring-security-webmvc-spring-boot-starter}" />
+                                        <group name="jacoco-multi">
+                                            <classfiles>
+                                                <fileset dir="${classes.api}" />
+                                                <fileset dir="${classes.impl}" />
+                                                <fileset dir="${classes.extensions.hazelcast}" />
+                                                <fileset dir="${classes.extensions.httpclient}" />
+                                                <fileset dir="${classes.extensions.servlet}" />
+                                                <fileset dir="${classes.extensions.oauth}" />
+                                                <fileset dir="${classes.stormpath-spring}" />
+                                                <fileset dir="${classes.stormpath-spring-webmvc}" />
+                                                <fileset dir="${classes.stormpath-spring-security}" />
+                                                <fileset dir="${classes.stormpath-spring-security-webmvc}" />
+                                                <fileset dir="${classes.stormpath-spring-boot-starter}" />
+                                                <fileset dir="${classes.stormpath-webmvc-spring-boot-starter}" />
+                                                <fileset dir="${classes.stormpath-spring-security-spring-boot-starter}" />
+                                                <fileset dir="${classes.stormpath-spring-security-webmvc-spring-boot-starter}" />
+                                            </classfiles>
+                                            <sourcefiles encoding="UTF-8">
+                                                <fileset dir="${sources.api}" />
+                                                <fileset dir="${sources.impl}" />
+                                                <fileset dir="${sources.extensions.hazelcast}" />
+                                                <fileset dir="${sources.extensions.httpclient}" />
+                                                <fileset dir="${sources.extensions.servlet}" />
+                                                <fileset dir="${sources.extensions.oauth}" />
+                                                <fileset dir="${sources.stormpath-spring}" />
+                                                <fileset dir="${sources.stormpath-spring-webmvc}" />
+                                                <fileset dir="${sources.stormpath-spring-security}" />
+                                                <fileset dir="${sources.stormpath-spring-security-webmvc}" />
+                                                <fileset dir="${sources.stormpath-spring-boot-starter}" />
+                                                <fileset dir="${sources.stormpath-webmvc-spring-boot-starter}" />
+                                                <fileset dir="${sources.stormpath-spring-security-spring-boot-starter}" />
+                                                <fileset dir="${sources.stormpath-spring-security-webmvc-spring-boot-starter}" />
 
-                                          <fileset dir="${generated-sources.api}" />
-                                          <fileset dir="${generated-sources.impl}" />
-                                          <fileset dir="${generated-sources.extensions.hazelcast}" />
-                                          <fileset dir="${generated-sources.extensions.httpclient}" />
-                                          <fileset dir="${generated-sources.extensions.servlet}" />
-                                          <fileset dir="${generated-sources.stormpath-spring}" />
-                                          <fileset dir="${generated-sources.stormpath-spring-webmvc}" />
-                                          <fileset dir="${generated-sources.stormpath-spring-security}" />
-                                          <fileset dir="${generated-sources.stormpath-spring-security-webmvc}" />
-                                          <fileset dir="${generated-sources.stormpath-spring-boot-starter}" />
-                                          <fileset dir="${generated-sources.stormpath-webmvc-spring-boot-starter}" />
-                                          <fileset dir="${generated-sources.stormpath-spring-security-spring-boot-starter}" />
-                                          <fileset dir="${generated-sources.stormpath-spring-security-webmvc-spring-boot-starter}" />
-                                        </sourcefiles>
-                                      </group>
+                                                <fileset dir="${generated-sources.api}" />
+                                                <fileset dir="${generated-sources.impl}" />
+                                                <fileset dir="${generated-sources.extensions.hazelcast}" />
+                                                <fileset dir="${generated-sources.extensions.httpclient}" />
+                                                <fileset dir="${generated-sources.extensions.servlet}" />
+                                                <fileset dir="${generated-sources.extensions.oauth}" />
+                                                <fileset dir="${generated-sources.stormpath-spring}" />
+                                                <fileset dir="${generated-sources.stormpath-spring-webmvc}" />
+                                                <fileset dir="${generated-sources.stormpath-spring-security}" />
+                                                <fileset dir="${generated-sources.stormpath-spring-security-webmvc}" />
+                                                <fileset dir="${generated-sources.stormpath-spring-boot-starter}" />
+                                                <fileset dir="${generated-sources.stormpath-webmvc-spring-boot-starter}" />
+                                                <fileset dir="${generated-sources.stormpath-spring-security-spring-boot-starter}" />
+                                                <fileset dir="${generated-sources.stormpath-spring-security-webmvc-spring-boot-starter}" />
+                                            </sourcefiles>
+                                        </group>
                                     </structure>
 
                                     <html destdir="${basedir}/target/coverage-report/html" />

--- a/pom.xml
+++ b/pom.xml
@@ -700,7 +700,7 @@
             <activation>
                 <!-- only run the IT tests on one of the JVM builds in Travis CI.  This ensures that we don't hammer
                 the REST api unnecessarily. -->
-                <jdk>1.6</jdk>
+                <jdk>1.7</jdk>
             </activation>
             <properties>
                 <skipITs>false</skipITs>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <testng.version>6.8</testng.version>
         <!-- false in JDK 6 profile (i.e. JDK 6 build has ITs turned on): -->
         <skipITs>true</skipITs>
+        <skipCoverage>true</skipCoverage>
 
         <!-- Sample App Dependencies: only required when running a sample app. Not required by SDK users at runtime: -->
         <jstl.version>1.2</jstl.version>
@@ -552,6 +553,44 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.5.201505241946</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <configuration>
+                    <repoToken>t8t2LuJ9cEyWl0MDlslaeVkEoBms21Nol</repoToken>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.15</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.4.2</version>
@@ -624,6 +663,37 @@
                 <skipITs>false</skipITs>
             </properties>
         </profile>
+        <!--<profile>-->
+            <!--<id>coverage</id>-->
+            <!--<build>-->
+                <!--<plugins>-->
+                    <!--<plugin><groupId>org.jacoco</groupId>-->
+                        <!--<artifactId>jacoco-maven-plugin</artifactId>-->
+                        <!--<version>0.7.5.201505241946</version>-->
+                        <!--<executions>-->
+                            <!--<execution>-->
+                                <!--<id>default-prepare-agent</id>-->
+                                <!--<goals>-->
+                                    <!--<goal>prepare-agent</goal>-->
+                                <!--</goals>-->
+                            <!--</execution>-->
+                            <!--<execution>-->
+                                <!--<id>default-report</id>-->
+                                <!--<phase>prepare-package</phase>-->
+                                <!--<goals>-->
+                                    <!--<goal>report</goal>-->
+                                <!--</goals>-->
+                            <!--</execution>-->
+                        <!--</executions>-->
+                    <!--</plugin>-->
+                    <!--<plugin>-->
+                        <!--<groupId>org.eluder.coveralls</groupId>-->
+                        <!--<artifactId>coveralls-maven-plugin</artifactId>-->
+                        <!--<version>2.2.0</version>-->
+                    <!--</plugin>-->
+                <!--</plugins>-->
+            <!--</build>-->
+        <!--</profile>-->
         <profile>
             <id>stormpath-signature</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -693,16 +693,6 @@
                 <!-- Issue 84: JDK 8 requires strict HTML.  We'll disable this strictness until we can
                      clean up the HTML source in JavaDoc comments: -->
                 <additionalparam>-Xdoclint:none</additionalparam>
-            </properties>
-        </profile>
-        <profile>
-            <id>it</id>
-            <activation>
-                <!-- only run the IT tests on one of the JVM builds in Travis CI.  This ensures that we don't hammer
-                the REST api unnecessarily. -->
-                <jdk>1.7</jdk>
-            </activation>
-            <properties>
                 <skipITs>false</skipITs>
                 <skipCoverage>false</skipCoverage>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -88,11 +88,14 @@
         <module>extensions</module>
         <module>examples</module>
         <module>tutorials</module>
+        <module>jacoco-multi-coverage</module>
     </modules>
 
     <properties>
 
         <jdk.version>1.6</jdk.version>
+
+        <jacoco.version>0.7.6.201602180812</jacoco.version>
 
         <slf4j.version>1.7.8</slf4j.version>
         <hazelcast.version>3.2.4</hazelcast.version>
@@ -117,6 +120,8 @@
         <!-- false in JDK 6 profile (i.e. JDK 6 build has ITs turned on): -->
         <skipITs>true</skipITs>
         <skipCoverage>false</skipCoverage>
+        <!-- should be post-integration-test when running unit and integration tests -->
+        <report-phase>test</report-phase>
 
         <!-- Sample App Dependencies: only required when running a sample app. Not required by SDK users at runtime: -->
         <jstl.version>1.2</jstl.version>
@@ -505,6 +510,14 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.15</version>
+                <configuration>
+                    <argLine>${surefireArgLine}</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.16</version>
                 <configuration>
@@ -519,6 +532,7 @@
                         <exclude>**/*ManualIT.java</exclude>
                         <exclude>**/*ManualIT.groovy</exclude>
                     </excludes>
+                    <argLine>${failsafeArgLine}</argLine>
                 </configuration>
                 <executions>
                     <execution>
@@ -555,7 +569,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.5.201505241946</version>
+                <version>${jacoco.version}</version>
                 <configuration>
                     <skip>${skipCoverage}</skip>
                     <excludes>
@@ -566,17 +580,47 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>default-prepare-agent</id>
+                        <id>pre-unit-test</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco.exec</destFile>
+                            <propertyName>surefireArgLine</propertyName>
+                        </configuration>
                     </execution>
                     <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pre-integration-test</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco.exec</destFile>
+                            <propertyName>failsafeArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>post-integration-test</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -587,16 +631,6 @@
                 <configuration>
                     <repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
                     <branch>coverage_jacoco_coveralls</branch>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.15</version>
-                <configuration>
-                    <systemPropertyVariables>
-                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <testng.version>6.8</testng.version>
         <!-- false in JDK 6 profile (i.e. JDK 6 build has ITs turned on): -->
         <skipITs>true</skipITs>
-        <skipCoverage>true</skipCoverage>
+        <skipCoverage>false</skipCoverage>
 
         <!-- Sample App Dependencies: only required when running a sample app. Not required by SDK users at runtime: -->
         <jstl.version>1.2</jstl.version>
@@ -556,15 +556,20 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.7.5.201505241946</version>
+                <configuration>
+                    <skip>${skipCoverage}</skip>
+                    <excludes>
+                        <exclude>api/**</exclude>
+                        <exclude>examples/**</exclude>
+                        <exclude>extensions/**</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
-                        <!--<configuration>-->
-                            <!--<propertyName>surefireArgLine</propertyName>-->
-                        <!--</configuration>-->
                     </execution>
                     <execution>
                         <id>default-report</id>
@@ -573,21 +578,7 @@
                             <goal>report</goal>
                         </goals>
                     </execution>
-                    <!--<execution>-->
-                        <!--<id>post-unit-test</id>-->
-                        <!--<phase>test</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>report</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
                 </executions>
-                <configuration>
-                    <excludes>
-                        <exclude>api/**</exclude>
-                        <exclude>examples/**</exclude>
-                        <exclude>extensions/**</exclude>
-                </excludes>
-    </configuration>
             </plugin>
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
@@ -679,40 +670,10 @@
             </activation>
             <properties>
                 <skipITs>false</skipITs>
+                <skipCoverage>false</skipCoverage>
             </properties>
         </profile>
 
-        <!--<profile>-->
-            <!--<id>coverage</id>-->
-            <!--<build>-->
-                <!--<plugins>-->
-                    <!--<plugin><groupId>org.jacoco</groupId>-->
-                        <!--<artifactId>jacoco-maven-plugin</artifactId>-->
-                        <!--<version>0.7.5.201505241946</version>-->
-                        <!--<executions>-->
-                            <!--<execution>-->
-                                <!--<id>default-prepare-agent</id>-->
-                                <!--<goals>-->
-                                    <!--<goal>prepare-agent</goal>-->
-                                <!--</goals>-->
-                            <!--</execution>-->
-                            <!--<execution>-->
-                                <!--<id>default-report</id>-->
-                                <!--<phase>prepare-package</phase>-->
-                                <!--<goals>-->
-                                    <!--<goal>report</goal>-->
-                                <!--</goals>-->
-                            <!--</execution>-->
-                        <!--</executions>-->
-                    <!--</plugin>-->
-                    <!--<plugin>-->
-                        <!--<groupId>org.eluder.coveralls</groupId>-->
-                        <!--<artifactId>coveralls-maven-plugin</artifactId>-->
-                        <!--<version>2.2.0</version>-->
-                    <!--</plugin>-->
-                <!--</plugins>-->
-            <!--</build>-->
-        <!--</profile>-->
         <profile>
             <id>stormpath-signature</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -562,6 +562,9 @@
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+                        <!--<configuration>-->
+                            <!--<propertyName>surefireArgLine</propertyName>-->
+                        <!--</configuration>-->
                     </execution>
                     <execution>
                         <id>default-report</id>
@@ -570,7 +573,20 @@
                             <goal>report</goal>
                         </goals>
                     </execution>
+                    <!--<execution>-->
+                        <!--<id>post-unit-test</id>-->
+                        <!--<phase>test</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>report</goal>-->
+                        <!--</goals>-->
+                    <!--</execution>-->
                 </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>**/api/**</exclude>
+                        <exclude>commons-logging</exclude>
+                </excludes>
+    </configuration>
             </plugin>
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
@@ -663,6 +679,7 @@
                 <skipITs>false</skipITs>
             </properties>
         </profile>
+
         <!--<profile>-->
             <!--<id>coverage</id>-->
             <!--<build>-->

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <logback.version>1.1.2</logback.version>
         <easymock.version>3.1</easymock.version>
         <testng.version>6.8</testng.version>
-        <!-- false in JDK 6 profile (i.e. JDK 6 build has ITs turned on): -->
+        <!-- false in JDK 8 profile (i.e. JDK 8 build has ITs turned on): -->
         <skipITs>true</skipITs>
         <skipCoverage>false</skipCoverage>
         <!-- should be post-integration-test when running unit and integration tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -583,8 +583,9 @@
                 </executions>
                 <configuration>
                     <excludes>
-                        <exclude>**/api/**</exclude>
-                        <exclude>commons-logging</exclude>
+                        <exclude>api/**</exclude>
+                        <exclude>examples/**</exclude>
+                        <exclude>extensions/**</exclude>
                 </excludes>
     </configuration>
             </plugin>
@@ -594,6 +595,7 @@
                 <version>4.1.0</version>
                 <configuration>
                     <repoToken>t8t2LuJ9cEyWl0MDlslaeVkEoBms21Nol</repoToken>
+                    <branch>coverage_jacoco_coveralls</branch>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -585,7 +585,7 @@
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.1.0</version>
                 <configuration>
-                    <repoToken>t8t2LuJ9cEyWl0MDlslaeVkEoBms21Nol</repoToken>
+                    <repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
                     <branch>coverage_jacoco_coveralls</branch>
                 </configuration>
             </plugin>

--- a/run_all_tests_with_coverage.sh
+++ b/run_all_tests_with_coverage.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+## Internal Stormpath: Refer to https://stormpath.atlassian.net/wiki/display/SDKS/Testing+Environments
+## for the environment variable settings below
+
+[ -z "$STORMPATH_BASE_URL" ] && echo "Need to set STORMPATH_BASE_URL" && exit 1
+[ -z "$STORMPATH_TEST_APPLICATION_HREF" ] && echo "Need to set STORMPATH_TEST_APPLICATION_HREF" && exit 1
+[ -z "$STORMPATH_API_KEY_ID" ] && echo "Need to set STORMPATH_API_KEY_ID" && exit 1
+[ -z "$STORMPATH_API_KEY_SECRET" ] && echo "Need to set STORMPATH_API_KEY_SECRET" && exit 1
+[ -z "$STORMPATH_API_KEY_ID_TWO_APP" ] && echo "Need to set STORMPATH_API_KEY_ID_TWO_APP" && exit 1
+[ -z "$STORMPATH_API_KEY_SECRET_TWO_APP" ] && echo "Need to set STORMPATH_API_KEY_SECRET_TWO_APP" && exit 1
+
+mvn --fail-never -DskipITs=false -Dreport-phase=post-integration-test clean verify && echo "All tests passed. Hooray!" || echo "Some tests failed. Boo."


### PR DESCRIPTION
resolves #431 

* Adds Jacoco test configuration for surefire and failsafe plugins
* Adds jacoco-mulit-coverage module for creating local aggregated coverage reports for unit and integration tests. This is necessary as jacoco does *not* natively support aggregated reports for multi-module maven projects
* Adds coveralls.io build to .travis.yml to report on aggregated code coverage for unit and integration tests.
* Moves docs build to oraclejdk7 from oraclejdk8
* Moves ITs run from jdk6 to jdk8 (reason is that maven coveralls plugin has to be jdk7 or newer AND we want the coveralls report to run after both unit and integration tests are run)
* Adds an initial unit test to oauth package as none existed before. This ensures that the oauth package is included in the stats for coverage
* Adds shell script to run all unit and integration tests and produce local aggregated coverage report