### PR TITLE
Updated quickstart documentation to better clarify how to enable and disable Spring Security

### DIFF
--- a/extensions/spring/boot/docs/source/quickstart.rst
+++ b/extensions/spring/boot/docs/source/quickstart.rst
@@ -42,7 +42,11 @@ Using your favorite dependency resolution build tool like Maven or Gradle, add t
     }
 
 
-In order to connect Stormpath and Spring Security, we need one small configuration class in your project:
+Spring Security
+^^^^^^^^^^^^^^^
+
+The Stormpath Default Spring Boot starter assumes Spring Security by default.  But to ensure they work
+together, you will need a Spring Security configuration class and apply the ``stormpath()`` hook:
 
 .. code-block:: java
     :emphasize-lines: 7
@@ -57,10 +61,22 @@ In order to connect Stormpath and Spring Security, we need one small configurati
         }
     }
 
-Without this, you will get a popup in your browser prompting for authentication, which is the default basic authentication for Spring Security.
+Without this, you will see a browser popup prompting for authentication, which is the default basic authentication behavior for Spring Security.
 
-Also, by default, all paths are locked down with Spring Security. Stormpath's Spring Security integration follows this idiomatic
-behavior.
+Also, by default, all paths are locked down with Spring Security. Stormpath's Spring Security integration follows this idiomatic behavior.
+
+Disabling Spring Security
+"""""""""""""""""""""""""
+
+If you do not want to use Spring Security, do not add the ``SpringSecurityWebAppConfig`` class shown above (or just comment out the ``http.apply(stormpath())`` line if you do not want to remove the class).  Also set the following two config properties:
+
+  .. code-block:: properties
+
+      # disable Stormpath's Spring Security support:
+      stormpath.spring.security.enabled = false
+
+      # disable Spring Security entirely:
+      security.basic.enabled = false
 
 That's it!  You're ready to start using Stormpath in your Spring Boot web application!  Can you believe how easy that was?
 
@@ -88,15 +104,7 @@ Did you experience any problems with this quickstart?  It might not have worked 
 
       stormpath.application.href = https://api.stormpath.com/v1/applications/YOUR_APPLICATION_ID
 
-* you don't want to use Spring Security or you are already using it and there are conflicts. You can easily disable Spring Security by adding two properties to ``application.properties``:
-
-  .. code-block:: properties
-
-     stormpath.spring.security.enabled = false
-     security.basic.enabled = false
-
 * your web app already uses web frameworks that make heavy use of servlet filters, like Spring Security or Apache Shiro. These could cause filter ordering conflicts, but the fix is easy - you just need to specify the specific order where you want the Stormpath filter relative to other filters.  You do this by adding the following to your Spring Boot ``application.properties`` file (where ``preferred_value`` is your preferred integer value):
-
 
   .. code-block:: properties
 
@@ -104,7 +112,7 @@ Did you experience any problems with this quickstart?  It might not have worked 
 
   By default, the ``StormpathFilter`` is ordered as ``Ordered.HIGHEST_PRECEDENCE``, but if you have multiple filters with that same order value, you might have to change the order of the other filters as well.
 
-* you're using the ``spring-boot-starter-parent`` as a ``parent`` and you are getting errors related to Spring Security. The ``stormpath-default-spring-boot-starter`` relies on Spring Security, version 4.0.x. The current release of the ``spring-boot-starter-parent`` is 1.3.0 and it also relies on Spring Security 4.0.x. Prior versions of the ``spring-boot-starter-parent`` rely on Spring Security 3.2.x. Our first recommendation is to use the latest version of the ``spring-boot-starter-parent``. However, if you must use earlier versions, there is a simple solution to this, which is to override the Spring Security version in your ``pom.xml``
+* you're using the ``spring-boot-starter-parent`` as a ``parent`` and you are getting errors related to Spring Security. The ``stormpath-default-spring-boot-starter`` relies on Spring Security 4.0.x. The current release of the ``spring-boot-starter-parent`` is 1.3.0 and it also relies on Spring Security 4.0.x. Prior versions of the ``spring-boot-starter-parent`` rely on Spring Security 3.2.x. Our first recommendation is to use the latest version of the ``spring-boot-starter-parent``. However, if you must use earlier versions, there is a simple solution to this, which is to override the Spring Security version in your ``pom.xml``
 
   .. code-block:: xml
       :emphasize-lines: 15


### PR DESCRIPTION
Fixes #484

Documentation (as opposed to code) was the chosen solution because it is not possible to both disable Spring Security and keep a SpringSecurity-specific configuration class in the code project.  There isn't anything we can do code-wise to automatically disable our behavior when user code explicitly calls `apply(stormpath())`.

The only real approach is to document that that method call should be removed as well as set some config properties.