### PR TITLE
Deprecated UsernamePasswordRequest and introduced UsernamePasswordRequests

### DIFF
--- a/api/src/main/java/com/stormpath/sdk/application/Application.java
+++ b/api/src/main/java/com/stormpath/sdk/application/Application.java
@@ -664,8 +664,7 @@ public interface Application extends AccountStoreHolder<Application>, Resource, 
      * <p/>
      * NOTE: If you already know the account store where the account resides, you can
      * specify it at the time the authentication request is created (for example,
-     * {@link com.stormpath.sdk.authc.UsernamePasswordRequest#UsernamePasswordRequest(String, char[],
-     * com.stormpath.sdk.directory.AccountStore)}).
+     * {@link UsernamePasswordRequestBuilder#inAccountStore(AccountStore)}).
      * This way you will be avoiding the authentication attempt to cycle through the Application's account stores.
      * <p/>
      * <h4>Example</h4>

--- a/api/src/main/java/com/stormpath/sdk/authc/AuthenticationRequest.java
+++ b/api/src/main/java/com/stormpath/sdk/authc/AuthenticationRequest.java
@@ -22,23 +22,23 @@ import com.stormpath.sdk.directory.AccountStore;
  *
  * <h4>Usage</h4>
  *
- * <p>While there can be multiple implementations of this interface to reflect different type of authentication
- * attempts, the most common scenario is when a user logs in to your application with username-password
- * authentication:</p>
+ * <p>While there can be multiple implementations of this interface (typically constructed by type-specific builders)
+ * to reflect different type of authentication attempts, the most common scenario is when a user logs in to your
+ * application with username-password authentication.  For example:</p>
  *
  * <pre>
  * String username = getUsername(httpServletRequest); //implement me
  * String password = getPassword(httpServletRequest); //implement me
  *
- * AuthenticationRequest authcRequest = new {@link UsernamePasswordRequest}(username, password);
+ * AuthenticationRequest authcRequest = {@link UsernamePasswordRequests#builder() UsernamePasswordRequests.builder()}.setUsername(username).setPassword(password).build();
  *
  * myApplication.{@link com.stormpath.sdk.application.Application#authenticateAccount(AuthenticationRequest)
  * authenticateAccount}(authcRequest);
  *
  * </pre>
  *
- * @see com.stormpath.sdk.authc.UsernamePasswordRequest
- * @see com.stormpath.sdk.application.Application#authenticateAccount(AuthenticationRequest)
+ * @see com.stormpath.sdk.authc.UsernamePasswordRequests
+ * @see com.stormpath.sdk.application.Application#authenticateAccount(AuthenticationRequest) Application.authenticateAccount(authcRequest)
  * @since 0.1
  */
 public interface AuthenticationRequest<P, C> {

--- a/api/src/main/java/com/stormpath/sdk/authc/UsernamePasswordRequest.java
+++ b/api/src/main/java/com/stormpath/sdk/authc/UsernamePasswordRequest.java
@@ -20,25 +20,28 @@ import com.stormpath.sdk.lang.Assert;
 import com.stormpath.sdk.lang.Classes;
 
 /**
- * A {@code UsernamePasswordRequest} is an {@code AuthenticationRequest} that represents a username (or email) +
- * password pair.  It optionally supports
- * {@link #setAccountStore(com.stormpath.sdk.directory.AccountStore) targeting an specific account store} as well for
- * customized authentication behavior.
  * <p>
- * NOTE: This class has been deprecated and will be removed in version 1.0. You can now use the new fluent interface
- * to create Username/Password Requests. For example:</p>
+ * NOTE: This class has been deprecated and will be removed in version 1.0. Use the
+ * {@link UsernamePasswordRequests#builder() UsernamePasswordRequests.builder()} instead.  For example:</p>
  * <pre>
- * AuthenticationRequest request = UsernamePasswordRequest.builder()
+ * AuthenticationRequest request = UsernamePasswordRequests.builder()
  *                         .setUsernameOrEmail(username)
  *                         .setPassword(submittedRawPlaintextPassword)
  *                         .build();
  * Account authenticated = application.authenticateAccount(request).getAccount();
  * </pre>
  *
+ * <p>A {@code UsernamePasswordRequest} is an {@code AuthenticationRequest} that represents a username (or email) +
+ * password pair.  It optionally supports
+ * {@link #setAccountStore(com.stormpath.sdk.directory.AccountStore) targeting an specific account store} as well for
+ * customized authentication behavior.</p>
+ *
  * @see UsernamePasswordRequestBuilder
  *
+ * @deprecated since 1.0.RC9. Use {@link UsernamePasswordRequests#builder() UsernamePasswordRequests.builder()} instead.
  * @since 0.2
  */
+@Deprecated
 public class UsernamePasswordRequest implements AuthenticationRequest<String, char[]> {
 
     /**
@@ -46,7 +49,9 @@ public class UsernamePasswordRequest implements AuthenticationRequest<String, ch
      *
      * @return a new {@link UsernamePasswordRequestBuilder} instance, used to construct {@link UsernamePasswordRequest}s.
      * @since 1.0.RC5
+     * @deprecated since 1.0.RC9. Use {@link UsernamePasswordRequests#builder() UsernamePasswordRequests.builder()} instead.
      */
+    @Deprecated
     public static UsernamePasswordRequestBuilder builder() {
         return (UsernamePasswordRequestBuilder) Classes.newInstance("com.stormpath.sdk.impl.authc.DefaultUsernamePasswordRequestBuilder");
     }
@@ -59,7 +64,9 @@ public class UsernamePasswordRequest implements AuthenticationRequest<String, ch
      * AuthenticationResult} resource that will be obtained after a successful authentication.
      * @see com.stormpath.sdk.authc.UsernamePasswordRequestBuilder#withResponseOptions(BasicAuthenticationOptions)
      * @since 1.0.RC5
+     * @deprecated since 1.0.RC9. Use {@link UsernamePasswordRequests#options() UsernamePasswordRequests.options()} instead.
      */
+    @Deprecated
     public static BasicAuthenticationOptions options() {
         return (BasicAuthenticationOptions) Classes.newInstance("com.stormpath.sdk.impl.authc.DefaultBasicAuthenticationOptions");
     }

--- a/api/src/main/java/com/stormpath/sdk/authc/UsernamePasswordRequest.java
+++ b/api/src/main/java/com/stormpath/sdk/authc/UsernamePasswordRequest.java
@@ -45,9 +45,9 @@ import com.stormpath.sdk.lang.Classes;
 public class UsernamePasswordRequest implements AuthenticationRequest<String, char[]> {
 
     /**
-     * Returns a new {@link UsernamePasswordRequestBuilder} instance, used to construct {@link UsernamePasswordRequest}s.
+     * Returns a new {@link UsernamePasswordRequestBuilder} instance, used to construct username/password-based {@link AuthenticationRequest}s.
      *
-     * @return a new {@link UsernamePasswordRequestBuilder} instance, used to construct {@link UsernamePasswordRequest}s.
+     * @return a new {@link UsernamePasswordRequestBuilder} instance, used to construct username/password-based {@link AuthenticationRequest}s.
      * @since 1.0.RC5
      * @deprecated since 1.0.RC9. Use {@link UsernamePasswordRequests#builder() UsernamePasswordRequests.builder()} instead.
      */

--- a/api/src/main/java/com/stormpath/sdk/authc/UsernamePasswordRequestBuilder.java
+++ b/api/src/main/java/com/stormpath/sdk/authc/UsernamePasswordRequestBuilder.java
@@ -18,9 +18,12 @@ package com.stormpath.sdk.authc;
 import com.stormpath.sdk.directory.AccountStore;
 
 /**
- * A Builder to construct {@link com.stormpath.sdk.authc.UsernamePasswordRequest UsernamePasswordRequest}s.
+ * A Builder to construct username/password-based {@link AuthenticationRequest}s.
  *
- * @see com.stormpath.sdk.authc.UsernamePasswordRequest#builder()
+ * It optionally supports {@link #inAccountStore(AccountStore) specifying an specific account store} as well for
+ * targeted authentication behavior.
+ *
+ * @see UsernamePasswordRequests#builder() UsernamePasswordRequests.builder()
  * @since 1.0.RC5
  */
 public interface UsernamePasswordRequestBuilder extends AuthenticationRequestBuilder<UsernamePasswordRequestBuilder> {

--- a/api/src/main/java/com/stormpath/sdk/authc/UsernamePasswordRequests.java
+++ b/api/src/main/java/com/stormpath/sdk/authc/UsernamePasswordRequests.java
@@ -1,0 +1,54 @@
+package com.stormpath.sdk.authc;
+
+import com.stormpath.sdk.lang.Classes;
+
+/**
+ * Static utility/helper methods for working with username/password-based {@link AuthenticationRequest}s.  Most methods
+ * are <a href="http://en.wikipedia.org/wiki/Factory_method_pattern">factory method</a>s used for forming
+ * Application-specific <a href="http://en.wikipedia.org/wiki/Fluent_interface">fluent DSL</a> queries. For example:
+ * <pre>
+ * AuthenticationRequest request = <b>UsernamePasswordRequests.builder()</b>
+ *                         .setUsernameOrEmail(username)
+ *                         .setPassword(submittedRawPlaintextPassword)
+ *                         .build();
+ * Account authenticated = application.authenticateAccount(request).getAccount();
+ * </pre>
+ *
+ * @see UsernamePasswordRequestBuilder
+ *
+ * @since 1.0.RC9
+ */
+public class UsernamePasswordRequests {
+
+    /**
+     * Returns a new {@link UsernamePasswordRequestBuilder} instance, used to construct {@link UsernamePasswordRequest}s.
+     *
+     * @return a new {@link UsernamePasswordRequestBuilder} instance, used to construct {@link UsernamePasswordRequest}s.
+     * @since 1.0.RC5
+     */
+    public static UsernamePasswordRequestBuilder builder() {
+        return (UsernamePasswordRequestBuilder) Classes.newInstance("com.stormpath.sdk.impl.authc.DefaultUsernamePasswordRequestBuilder");
+    }
+
+    /**
+     * Returns a new {@link BasicAuthenticationOptions} instance, that may be used to customize the {@link com.stormpath.sdk.authc.AuthenticationResult
+     * AuthenticationResult} resource that will be obtained after a successful authentication.  For example:
+     *  <pre>
+     * AuthenticationRequest request = UsernamePasswordRequests.builder()
+     *                         .setUsernameOrEmail(username)
+     *                         .setPassword(submittedRawPlaintextPassword)
+     *                         <b>.withResponseOptions(UsernamePasswordRequests.options().withAccount())</b>
+     *                         .build();
+     * Account authenticated = application.authenticateAccount(request).getAccount();
+     * </pre>
+     *
+     *
+     * @return a new {@link BasicAuthenticationOptions} instance, that may be used to customize the {@link com.stormpath.sdk.authc.AuthenticationResult
+     * AuthenticationResult} resource that will be obtained after a successful authentication.
+     * @see com.stormpath.sdk.authc.UsernamePasswordRequestBuilder#withResponseOptions(BasicAuthenticationOptions)
+     * @since 1.0.RC5
+     */
+    public static BasicAuthenticationOptions options() {
+        return (BasicAuthenticationOptions) Classes.newInstance("com.stormpath.sdk.impl.authc.DefaultBasicAuthenticationOptions");
+    }
+}

--- a/api/src/main/java/com/stormpath/sdk/authc/UsernamePasswordRequests.java
+++ b/api/src/main/java/com/stormpath/sdk/authc/UsernamePasswordRequests.java
@@ -15,15 +15,14 @@ import com.stormpath.sdk.lang.Classes;
  * </pre>
  *
  * @see UsernamePasswordRequestBuilder
- *
  * @since 1.0.RC9
  */
 public class UsernamePasswordRequests {
 
     /**
-     * Returns a new {@link UsernamePasswordRequestBuilder} instance, used to construct {@link UsernamePasswordRequest}s.
+     * Returns a new {@link UsernamePasswordRequestBuilder} instance, used to construct username/password-based {@link AuthenticationRequest}s.
      *
-     * @return a new {@link UsernamePasswordRequestBuilder} instance, used to construct {@link UsernamePasswordRequest}s.
+     * @return a new {@link UsernamePasswordRequestBuilder} instance, used to construct username/password-based {@link AuthenticationRequest}s.
      * @since 1.0.RC5
      */
     public static UsernamePasswordRequestBuilder builder() {
@@ -33,7 +32,7 @@ public class UsernamePasswordRequests {
     /**
      * Returns a new {@link BasicAuthenticationOptions} instance, that may be used to customize the {@link com.stormpath.sdk.authc.AuthenticationResult
      * AuthenticationResult} resource that will be obtained after a successful authentication.  For example:
-     *  <pre>
+     * <pre>
      * AuthenticationRequest request = UsernamePasswordRequests.builder()
      *                         .setUsernameOrEmail(username)
      *                         .setPassword(submittedRawPlaintextPassword)
@@ -41,7 +40,6 @@ public class UsernamePasswordRequests {
      *                         .build();
      * Account authenticated = application.authenticateAccount(request).getAccount();
      * </pre>
-     *
      *
      * @return a new {@link BasicAuthenticationOptions} instance, that may be used to customize the {@link com.stormpath.sdk.authc.AuthenticationResult
      * AuthenticationResult} resource that will be obtained after a successful authentication.

--- a/api/src/main/java/com/stormpath/sdk/organization/Organization.java
+++ b/api/src/main/java/com/stormpath/sdk/organization/Organization.java
@@ -314,8 +314,7 @@ public interface Organization extends AccountStoreHolder<Organization>, Resource
      * <p/>
      * NOTE: If you already know the account store where the account resides, you can
      * specify it at the time the authentication request is created (for example,
-     * {@link com.stormpath.sdk.authc.UsernamePasswordRequest#UsernamePasswordRequest(String, char[],
-     * com.stormpath.sdk.directory.AccountStore)}).
+     * {@link com.stormpath.sdk.authc.UsernamePasswordRequestBuilder#inAccountStore(AccountStore)}).
      * This way you will be avoiding the authentication attempt to cycle through the Organization's account stores.
      * <p/>
      * <h4>Example</h4>

--- a/examples/quickstart/src/main/java/quickstart/Quickstart.java
+++ b/examples/quickstart/src/main/java/quickstart/Quickstart.java
@@ -22,7 +22,7 @@ import com.stormpath.sdk.application.ApplicationList;
 import com.stormpath.sdk.application.Applications;
 import com.stormpath.sdk.authc.AuthenticationRequest;
 import com.stormpath.sdk.authc.AuthenticationResult;
-import com.stormpath.sdk.authc.UsernamePasswordRequest;
+import com.stormpath.sdk.authc.UsernamePasswordRequests;
 import com.stormpath.sdk.client.Client;
 import com.stormpath.sdk.client.ClientBuilder;
 import com.stormpath.sdk.client.Clients;
@@ -61,7 +61,7 @@ public class Quickstart {
 
         // Retrieve your application
         ApplicationList applications = tenant.getApplications(
-            Applications.where(Applications.name().eqIgnoreCase(APPLICATION_NAME))
+                Applications.where(Applications.name().eqIgnoreCase(APPLICATION_NAME))
         );
 
         Application application = applications.iterator().next();
@@ -104,10 +104,10 @@ public class Quickstart {
         String rawPassword = "Changeme1";
 
         // Create an authentication request using the credentials
-        AuthenticationRequest request = UsernamePasswordRequest.builder()
-            .setUsernameOrEmail(usernameOrEmail)
-            .setPassword(rawPassword)
-            .build();
+        AuthenticationRequest request = UsernamePasswordRequests.builder()
+                .setUsernameOrEmail(usernameOrEmail)
+                .setPassword(rawPassword)
+                .build();
 
         //Now let's authenticate the account with the application:
         try {

--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/client/PasswordResetAndAuthenticationManualIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/client/PasswordResetAndAuthenticationManualIT.groovy
@@ -19,7 +19,7 @@ import com.stormpath.sdk.account.Account
 import com.stormpath.sdk.account.PasswordResetToken
 import com.stormpath.sdk.application.Application
 import com.stormpath.sdk.application.ApplicationList
-import com.stormpath.sdk.authc.UsernamePasswordRequest
+import com.stormpath.sdk.authc.UsernamePasswordRequests
 import com.stormpath.sdk.impl.api.ClientApiKey
 import com.stormpath.sdk.impl.client.DefaultClientBuilder
 import com.stormpath.sdk.tenant.Tenant
@@ -83,7 +83,7 @@ class PasswordResetAndAuthenticationManualIT {
 //        println "appToTest = $appToTest"
 //        println "acctToTest = $acctToTest"
 
-        UsernamePasswordRequest request = new UsernamePasswordRequest(acctToTest.username, oldPassword)
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(acctToTest.username).setPassword(oldPassword).build()
         println(appToTest.authenticateAccount(request).getAccount())
 
 //     1 - I create a password reset token
@@ -94,7 +94,7 @@ class PasswordResetAndAuthenticationManualIT {
 
 //     3 - I get the Account from the PasswordResetToken
         Account accountFromToken = token.account
-        request = new UsernamePasswordRequest(accountFromToken.username, oldPassword)
+        request = UsernamePasswordRequests.builder().setUsernameOrEmail(accountFromToken.username).setPassword(oldPassword).build()
         appToTest.authenticateAccount(request)
 
 //     4 - I set the new password on the Account
@@ -103,7 +103,7 @@ class PasswordResetAndAuthenticationManualIT {
         accountFromToken.save()
 
 //     6 - I try to authenticate with the new password
-        request = new UsernamePasswordRequest(accountFromToken.username, newPassword)
+        request = UsernamePasswordRequests.builder().setUsernameOrEmail(accountFromToken.username).setPassword(newPassword).build()
         appToTest.authenticateAccount(request)
 
         long stop = System.currentTimeMillis();

--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/client/PasswordResetManualIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/client/PasswordResetManualIT.groovy
@@ -18,7 +18,7 @@ package com.stormpath.sdk.client
 import com.stormpath.sdk.account.Account
 import com.stormpath.sdk.application.Application
 import com.stormpath.sdk.application.ApplicationList
-import com.stormpath.sdk.authc.UsernamePasswordRequest
+import com.stormpath.sdk.authc.UsernamePasswordRequests
 import com.stormpath.sdk.tenant.Tenant
 import org.testng.annotations.Test
 
@@ -83,7 +83,7 @@ class PasswordResetManualIT extends ClientIT {
         acct.password = newPassword
         acct.save()
 
-        def request = new UsernamePasswordRequest(email, newPassword)
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(email).setPassword(newPassword).build()
         Account authenticated = appToTest.authenticateAccount(request).account
 
         assertEquals acct.href, authenticated.href
@@ -112,7 +112,7 @@ class PasswordResetManualIT extends ClientIT {
 
         assertEquals(email, acct.email, "Could not retrieve correct account during password reset.")
 
-        def request = new UsernamePasswordRequest(email, newPassword)
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(email).setPassword(newPassword).build()
         Account authenticated = appToTest.authenticateAccount(request).account
 
         assertEquals acct.href, authenticated.href

--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
@@ -28,6 +28,7 @@ import com.stormpath.sdk.application.Application
 import com.stormpath.sdk.application.ApplicationAccountStoreMapping
 import com.stormpath.sdk.application.ApplicationAccountStoreMappingList
 import com.stormpath.sdk.application.Applications
+import com.stormpath.sdk.authc.UsernamePasswordRequests
 import com.stormpath.sdk.directory.AccountStore
 import com.stormpath.sdk.oauth.AccessToken
 import com.stormpath.sdk.oauth.Authenticators
@@ -37,7 +38,6 @@ import com.stormpath.sdk.oauth.JwtAuthenticationRequest
 import com.stormpath.sdk.oauth.OauthPolicy
 import com.stormpath.sdk.oauth.PasswordGrantRequest
 import com.stormpath.sdk.oauth.RefreshGrantRequest
-import com.stormpath.sdk.authc.UsernamePasswordRequest
 import com.stormpath.sdk.client.AuthenticationScheme
 import com.stormpath.sdk.client.Client
 import com.stormpath.sdk.client.ClientIT
@@ -98,7 +98,7 @@ class ApplicationIT extends ClientIT {
         acct.surname = 'Smith'
         acct = app.createAccount(Accounts.newCreateRequestFor(acct).setRegistrationWorkflowEnabled(false).build())
 
-        def request = new UsernamePasswordRequest(username, password)
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).build()
         def result = app.authenticateAccount(request)
 
         def cachedAccount = result.getAccount()
@@ -116,7 +116,7 @@ class ApplicationIT extends ClientIT {
         Account account = client.instantiate(Account)
         account.givenName = 'John'
         account.surname = 'DELETEME'
-        account.email =  email
+        account.email = email
         account.password = 'Changeme1!'
 
         def created = app.createAccount(account)
@@ -312,13 +312,15 @@ class ApplicationIT extends ClientIT {
         deleteOnTeardown(acct)
 
         //Account belongs to dir1, therefore login must succeed
-        def request = new UsernamePasswordRequest(username, password, accountStoreMapping1.getAccountStore())
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password)
+                .inAccountStore(accountStoreMapping1.getAccountStore()).build()
         def result = app.authenticateAccount(request)
         assertEquals(result.getAccount().getUsername(), acct.username)
 
         try {
             //Account does not belong to dir2, therefore login must fail
-            request = new UsernamePasswordRequest(username, password, accountStoreMapping2.getAccountStore())
+            request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password)
+                    .inAccountStore(accountStoreMapping2.getAccountStore()).build()
             app.authenticateAccount(request)
             fail("Should have thrown due to invalid username/password");
         } catch (Exception e) {
@@ -326,7 +328,7 @@ class ApplicationIT extends ClientIT {
         }
 
         //No account store has been defined, therefore login must succeed
-        request = new UsernamePasswordRequest(username, password)
+        request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).build()
         result = app.authenticateAccount(request)
         assertEquals(result.getAccount().getUsername(), acct.username)
     }
@@ -378,12 +380,12 @@ class ApplicationIT extends ClientIT {
         deleteOnTeardown(accountStoreMapping)
 
         //Account belongs to org, therefore login must succeed
-        def request = new UsernamePasswordRequest(username, password, org)
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).inAccountStore(org).build()
         def result = app.authenticateAccount(request)
         assertEquals(result.getAccount().getUsername(), acct.username)
 
         //No account store has been defined, therefore login must succeed
-        request = new UsernamePasswordRequest(username, password)
+        request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).build()
         result = app.authenticateAccount(request)
         assertEquals(result.getAccount().getUsername(), acct.username)
 
@@ -397,7 +399,7 @@ class ApplicationIT extends ClientIT {
 
         //Account does not belong to org2, therefore login must fail
         try {
-            request = new UsernamePasswordRequest(username, password, org2)
+            request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).inAccountStore(org2).build()
             result = app.authenticateAccount(request)
             fail("Should have thrown due to invalid username/password");
         } catch (Exception e) {
@@ -452,7 +454,9 @@ class ApplicationIT extends ClientIT {
 
         for (ApplicationAccountStoreMapping mapping : accountStoreMappings) {
             AccountStore accountStore = mapping.getAccountStore();
-            if (!(accountStore instanceof Organization)) { continue; }
+            if (!(accountStore instanceof Organization)) {
+                continue;
+            }
             Organization organization = (Organization) accountStore;
             assertNotNull organization.href
             assertEquals organization.name, name
@@ -616,7 +620,7 @@ class ApplicationIT extends ClientIT {
      * @since 1.0.RC8
      */
     @Test
-    void testSamlProperties(){
+    void testSamlProperties() {
         def app = createTempApp()
 
         def samlPolicy = app.getSamlPolicy()
@@ -646,10 +650,10 @@ class ApplicationIT extends ClientIT {
         assertEquals callbackUris.iterator().next(), uri
 
         List<String> testUris = new ArrayList<String>()
-            testUris.add("https://myapplication.com/callback1")
-            testUris.add("https://myapplication.com/callback2")
-            testUris.add("https://myapplication.com/callback3")
-            testUris.add("https://myapplication.com/callback4")
+        testUris.add("https://myapplication.com/callback1")
+        testUris.add("https://myapplication.com/callback2")
+        testUris.add("https://myapplication.com/callback3")
+        testUris.add("https://myapplication.com/callback4")
 
         app.setAuthorizedCallbackUris(testUris)
         callbackUris = app.getAuthorizedCallbackUris()
@@ -694,8 +698,10 @@ class ApplicationIT extends ClientIT {
 
         assertNotNull appApiKey
 
-        assertTrue(appApiKey.account.propertyNames.size() > 1) // testing expansion on the object retrieved from the server
-        assertTrue(appApiKey.tenant.propertyNames.size() > 1) // testing expansion on the object retrieved from the server
+        assertTrue(appApiKey.account.propertyNames.size() > 1)
+        // testing expansion on the object retrieved from the server
+        assertTrue(appApiKey.tenant.propertyNames.size() > 1)
+        // testing expansion on the object retrieved from the server
 
         assertNotNull appApiKey2
 
@@ -833,13 +839,13 @@ class ApplicationIT extends ClientIT {
         Account account = client.instantiate(Account)
         account.givenName = 'John'
         account.surname = 'DELETEME'
-        account.email =  email
+        account.email = email
         account.password = 'Changeme1!'
 
         app.createAccount(account)
         deleteOnTeardown(account)
 
-        return  account
+        return account
     }
 
     String decryptSecretFromCacheMap(Map cacheMap) {
@@ -903,7 +909,8 @@ class ApplicationIT extends ClientIT {
     /**
      * @since 1.0.RC
      */
-    @Test(enabled = false) //ignoring because of sporadic Travis failures
+    @Test(enabled = false)
+    //ignoring because of sporadic Travis failures
     void testGetApplicationsWithMapViaTenantActions() {
         def map = new HashMap<String, Object>()
         def appList = client.getApplications(map)
@@ -914,7 +921,8 @@ class ApplicationIT extends ClientIT {
     /**
      * @since 1.0.RC
      */
-    @Test(enabled = false) //ignoring because of sporadic Travis failures
+    @Test(enabled = false)
+    //ignoring because of sporadic Travis failures
     void testGetApplicationsWithAppCriteriaViaTenantActions() {
         def appCriteria = Applications.criteria()
         def appList = client.getApplications(appCriteria)
@@ -945,7 +953,8 @@ class ApplicationIT extends ClientIT {
     /**
      * @since 1.0.RC3
      */
-    @Test(enabled = false) //ignoring because of sporadic Travis failures
+    @Test(enabled = false)
+    //ignoring because of sporadic Travis failures
     void testAddAccountStore_Dirs() {
         def count = 1
         while (count >= 0) { //re-trying once
@@ -1012,7 +1021,8 @@ class ApplicationIT extends ClientIT {
     /**
      * @since 1.0.RC3
      */
-    @Test(enabled = false) //ignoring because of sporadic Travis failures
+    @Test(enabled = false)
+    //ignoring because of sporadic Travis failures
     void testAddAccountStore_Groups() {
         def count = 1
         while (count >= 0) { //re-trying once
@@ -1081,11 +1091,11 @@ class ApplicationIT extends ClientIT {
         }
     }
 
-
     /**
      * @since 1.0.RC3
      */
-    @Test(enabled = false, expectedExceptions = IllegalArgumentException)  //ignoring because of sporadic Travis failures
+    @Test(enabled = false, expectedExceptions = IllegalArgumentException)
+    //ignoring because of sporadic Travis failures
     void testAddAccountStore_DirAndGroupMatch() {
 
         Directory dir01 = client.instantiate(Directory)
@@ -1136,7 +1146,8 @@ class ApplicationIT extends ClientIT {
     /**
      * @since 1.0.RC3
      */
-    @Test(enabled = false, expectedExceptions = IllegalArgumentException) //ignoring because of sporadic Travis failures
+    @Test(enabled = false, expectedExceptions = IllegalArgumentException)
+    //ignoring because of sporadic Travis failures
     void testAddAccountStore_MultipleGroupCriteria() {
 
         Directory dir01 = client.instantiate(Directory)
@@ -1182,7 +1193,7 @@ class ApplicationIT extends ClientIT {
         try {
             app.getAccounts().single()
             fail("should have thrown")
-        } catch ( IllegalStateException e) {
+        } catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "Only a single resource was expected, but this list contains more than one item.")
         }
 
@@ -1191,7 +1202,7 @@ class ApplicationIT extends ClientIT {
         try {
             app.getAccounts(Accounts.where(Accounts.email().eqIgnoreCase("thisEmailDoesNotBelong@ToAnAccount.com"))).single()
             fail("should have thrown")
-        } catch ( IllegalStateException e) {
+        } catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "This list is empty while it was expected to contain one (and only one) element.")
         }
     }
@@ -1245,8 +1256,8 @@ class ApplicationIT extends ClientIT {
         acct.surname = 'Smith'
         acct = app.createAccount(Accounts.newCreateRequestFor(acct).setRegistrationWorkflowEnabled(false).build())
 
-        def options = UsernamePasswordRequest.options().withAccount()
-        def request = UsernamePasswordRequest.builder().setUsernameOrEmail(username).setPassword(password).withResponseOptions(options).build()
+        def options = UsernamePasswordRequests.options()
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).withResponseOptions(options).build()
 
         def result = app.authenticateAccount(request)
 
@@ -1256,7 +1267,7 @@ class ApplicationIT extends ClientIT {
         assertEquals properties.get("account").get("email"), acct.email
 
         //Let's re-authenticate without expansion
-        request = UsernamePasswordRequest.builder().setUsernameOrEmail(username).setPassword(password).build()
+        request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).build()
         result = app.authenticateAccount(request)
 
         //Let's check that there is no expansion
@@ -1264,9 +1275,10 @@ class ApplicationIT extends ClientIT {
         assertTrue properties.get("account").size() == 1
     }
 
-    private static assertAccountStoreMappingListSize(ApplicationAccountStoreMappingList accountStoreMappings, int expectedSize) {
+    private
+    static assertAccountStoreMappingListSize(ApplicationAccountStoreMappingList accountStoreMappings, int expectedSize) {
         int qty = 0;
-        for(ApplicationAccountStoreMapping accountStoreMapping : accountStoreMappings) {
+        for (ApplicationAccountStoreMapping accountStoreMapping : accountStoreMappings) {
             qty++;
         }
         assertEquals(qty, expectedSize)
@@ -1276,7 +1288,7 @@ class ApplicationIT extends ClientIT {
      * @since 1.0.RC4.6
      */
     @Test
-    void testSaveWithResponseOptions(){
+    void testSaveWithResponseOptions() {
 
         def app = createTempApp()
         def href = app.getHref()
@@ -1321,7 +1333,8 @@ class ApplicationIT extends ClientIT {
         acct = app.createAccount(Accounts.newCreateRequestFor(acct).setRegistrationWorkflowEnabled(false).build())
         deleteOnTeardown(acct)
 
-        def account = app.authenticateAccount(new UsernamePasswordRequest(username, password)).getAccount()
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).build()
+        def account = app.authenticateAccount(request).getAccount()
         assertEquals account.getEmail(), email
 
         PasswordResetToken token = app.sendPasswordResetEmail(email)
@@ -1331,14 +1344,16 @@ class ApplicationIT extends ClientIT {
         account = app.resetPassword(token.getValue(), "newPassword123!")
 
         try {
-            account = app.authenticateAccount(new UsernamePasswordRequest(username, password)).getAccount()
+            def upreq = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).build()
+            account = app.authenticateAccount(upreq).getAccount()
             fail("should have thrown due to wrong password")
         } catch (ResourceException e) {
             assertTrue(e.getMessage().contains("Login attempt failed because the specified password is incorrect."))
         }
 
         //login with the new password
-        account = app.authenticateAccount(new UsernamePasswordRequest(username, "newPassword123!")).getAccount()
+        def upreq = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword("newPassword123!").build()
+        account = app.authenticateAccount(upreq).getAccount()
 
         assertEquals account.getEmail(), email
     }
@@ -1361,10 +1376,10 @@ class ApplicationIT extends ClientIT {
         def app = createTempApp()
 
         Account account = client.instantiate(Account)
-            .setGivenName('John')
-            .setSurname('DeleteMe')
-            .setEmail("deletejohn@test.com")
-            .setPassword('$2y$12$QjSH496pcT5CEbzjD/vtVeH03tfHKFy36d4J0Ltp3lRtee9HDxY3K')
+                .setGivenName('John')
+                .setSurname('DeleteMe')
+                .setEmail("deletejohn@test.com")
+                .setPassword('$2y$12$QjSH496pcT5CEbzjD/vtVeH03tfHKFy36d4J0Ltp3lRtee9HDxY3K')
 
         def created = app.createAccount(Accounts.newCreateRequestFor(account)
                 .setRegistrationWorkflowEnabled(false)
@@ -1376,7 +1391,8 @@ class ApplicationIT extends ClientIT {
         def found = app.getAccounts(Accounts.where(Accounts.email().eqIgnoreCase("deletejohn@test.com"))).single()
         assertEquals(created.href, found.href)
 
-        found = app.authenticateAccount(new UsernamePasswordRequest("deletejohn@test.com", "rasmuslerdorf")).getAccount()
+        def upreq = UsernamePasswordRequests.builder().setUsernameOrEmail("deletejohn@test.com").setPassword("rasmuslerdorf").build()
+        found = app.authenticateAccount(upreq).getAccount()
         assertEquals(created.href, found.href)
     }
 
@@ -1391,19 +1407,20 @@ class ApplicationIT extends ClientIT {
         Account account = client.instantiate(Account)
         account.givenName = 'John'
         account.surname = 'DeleteMe'
-        account.email =  "deletejohn@test.com"
+        account.email = "deletejohn@test.com"
         account.password = '$INVALID$04$RZPSLGUz3dRdm7aRfxOeYuKeueSPW2YaTpRkszAA31wcPpyg6zkGy'
 
         try {
             app.createAccount(Accounts.newCreateRequestFor(account).setPasswordFormat(PasswordFormat.MCF).build())
             fail("Should have thrown")
-        } catch (ResourceException e){
+        } catch (ResourceException e) {
             assertEquals e.getCode(), 2006
             assertTrue e.getDeveloperMessage().contains("is in an invalid format")
         }
     }
 
     /* @since 1.0.RC7 */
+
     @Test
     void testCreateAndRefreshTokenForAppAccount() {
 
@@ -1414,7 +1431,7 @@ class ApplicationIT extends ClientIT {
         Account account = client.instantiate(Account)
         account.givenName = 'John'
         account.surname = 'DELETEME'
-        account.email =  email
+        account.email = email
         account.password = 'Change&45+me1!'
 
         def created = app.createAccount(account)
@@ -1429,9 +1446,9 @@ class ApplicationIT extends ClientIT {
         assertNotNull result.accessTokenHref
         assertEquals result.getAccessToken().getAccount().getEmail(), email
         assertEquals result.getAccessToken().getApplication().getHref(), app.href
-        assertEquals(((Map)result.getAccessToken().getExpandedJwt().get("claims")).get("iss"), app.getHref())
-        assertNotNull(((Map)result.getAccessToken().getExpandedJwt().get("claims")).get("rti"))
-        assertEquals(((Map)result.getAccessToken().getExpandedJwt().get("header")).get("alg"), SignatureAlgorithm.HS256.toString())
+        assertEquals(((Map) result.getAccessToken().getExpandedJwt().get("claims")).get("iss"), app.getHref())
+        assertNotNull(((Map) result.getAccessToken().getExpandedJwt().get("claims")).get("rti"))
+        assertEquals(((Map) result.getAccessToken().getExpandedJwt().get("header")).get("alg"), SignatureAlgorithm.HS256.toString())
         assertNotNull(result.getAccessToken().getExpandedJwt().get("signature"))
 
         RefreshGrantRequest request = Oauth2Requests.REFRESH_GRANT_REQUEST.builder().setRefreshToken(result.getRefreshTokenString()).build();
@@ -1445,15 +1462,16 @@ class ApplicationIT extends ClientIT {
         assertTrue(result.getRefreshToken().getHref().contains("/refreshTokens/"))
         assertEquals result.getRefreshToken().getAccount().getEmail(), email
         assertEquals result.getRefreshToken().getApplication().getHref(), app.href
-        assertEquals(((Map)result.getRefreshToken().getExpandedJwt().get("claims")).get("sub"), account.getHref())
-        assertNull(((Map)result.getRefreshToken().getExpandedJwt().get("claims")).get("rti"))
-        assertEquals(((Map)result.getRefreshToken().getExpandedJwt().get("header")).get("alg"), SignatureAlgorithm.HS256.toString())
+        assertEquals(((Map) result.getRefreshToken().getExpandedJwt().get("claims")).get("sub"), account.getHref())
+        assertNull(((Map) result.getRefreshToken().getExpandedJwt().get("claims")).get("rti"))
+        assertEquals(((Map) result.getRefreshToken().getExpandedJwt().get("header")).get("alg"), SignatureAlgorithm.HS256.toString())
         assertNotNull(result.getRefreshToken().getExpandedJwt().get("signature"))
     }
 
     /* @since 1.0.RC7 */
+
     @Test
-    void testRetrieveAndUpdateOauthPolicy(){
+    void testRetrieveAndUpdateOauthPolicy() {
         def app = createTempApp()
 
         OauthPolicy oauthPolicy = app.getOauthPolicy()
@@ -1472,6 +1490,7 @@ class ApplicationIT extends ClientIT {
     }
 
     /* @since 1.0.RC7 */
+
     @Test
     void testAuthenticateAndDeleteTokenForAppAccount() {
 
@@ -1505,7 +1524,7 @@ class ApplicationIT extends ClientIT {
             //try to authenticate deleted token
             Authenticators.JWT_AUTHENTICATOR.forApplication(app).authenticate(authRequest)
             fail("Should have thrown due to unexistent token")
-        } catch (Exception e){
+        } catch (Exception e) {
             def message = e.getMessage()
             assertTrue message.contains("Token does not exist. This can occur if the token has been manually deleted, or if the token has expired and removed by Stormpath.")
         }
@@ -1515,24 +1534,25 @@ class ApplicationIT extends ClientIT {
     }
 
     /* @since 1.0.RC8.3 */
+
     @Test
     void testAttemptAuthenticationWithRefreshToken() {
         def app = createTempApp()
         def account = createTestAccount(app)
 
         PasswordGrantRequest grantRequest = Oauth2Requests.PASSWORD_GRANT_REQUEST.builder()
-            .setLogin(account.email)
-            .setPassword("Changeme1!")
-            .build()
+                .setLogin(account.email)
+                .setPassword("Changeme1!")
+                .build()
 
         def grantResult = Authenticators.PASSWORD_GRANT_AUTHENTICATOR
-            .forApplication(app)
-            .authenticate(grantRequest)
+                .forApplication(app)
+                .authenticate(grantRequest)
 
         // Authenticate token against Stormpath using refresh token <--- INVALID
         JwtAuthenticationRequest authRequest = Oauth2Requests.JWT_AUTHENTICATION_REQUEST.builder()
-            .setJwt(grantResult.getRefreshTokenString())
-            .build()
+                .setJwt(grantResult.getRefreshTokenString())
+                .build()
 
         try {
             Authenticators.JWT_AUTHENTICATOR.forApplication(app).authenticate(authRequest)
@@ -1544,6 +1564,7 @@ class ApplicationIT extends ClientIT {
     }
 
     /* @since 1.0.RC8.3 */
+
     @Test
     void testAttemptAuthenticationWithRefreshTokenWithLocalValidation() {
         def app = createTempApp()
@@ -1572,8 +1593,8 @@ class ApplicationIT extends ClientIT {
         }
     }
 
-
     /* @since 1.0.RC7 */
+
     @Test
     void testInvalidTokenViaLocalValidation() {
 
@@ -1593,7 +1614,7 @@ class ApplicationIT extends ClientIT {
             //try to authenticate a tampered token
             Authenticators.JWT_AUTHENTICATOR.forApplication(app).withLocalValidation().authenticate(authRequest)
             fail("Should have thrown")
-        } catch (Exception e){
+        } catch (Exception e) {
             def message = e.getMessage()
             assertTrue message.equals("JWT failed validation; it cannot be trusted.")
         }
@@ -1604,7 +1625,7 @@ class ApplicationIT extends ClientIT {
             //try to use a valid token with another application
             Authenticators.JWT_AUTHENTICATOR.forApplication(app2).withLocalValidation().authenticate(authRequest)
             fail("Should have thrown")
-        } catch (Exception e){
+        } catch (Exception e) {
             def message = e.getMessage()
             assertTrue message.equals("JWT failed validation; it cannot be trusted.")
         }

--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
@@ -1256,7 +1256,7 @@ class ApplicationIT extends ClientIT {
         acct.surname = 'Smith'
         acct = app.createAccount(Accounts.newCreateRequestFor(acct).setRegistrationWorkflowEnabled(false).build())
 
-        def options = UsernamePasswordRequests.options()
+        def options = UsernamePasswordRequests.options().withAccount()
         def request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).withResponseOptions(options).build()
 
         def result = app.authenticateAccount(request)

--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/resource/ResourceExceptionIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/resource/ResourceExceptionIT.groovy
@@ -19,7 +19,7 @@ import com.stormpath.sdk.application.Application
 import com.stormpath.sdk.application.Applications
 import com.stormpath.sdk.authc.AuthenticationRequest
 import com.stormpath.sdk.authc.AuthenticationResult
-import com.stormpath.sdk.authc.UsernamePasswordRequest
+import com.stormpath.sdk.authc.UsernamePasswordRequests
 import com.stormpath.sdk.client.ClientIT
 import com.stormpath.sdk.directory.Directories
 import org.testng.annotations.Test
@@ -45,7 +45,7 @@ class ResourceExceptionIT extends ClientIT {
         deleteOnTeardown(directory)
 
         // login+password authentication request
-        AuthenticationRequest request = new UsernamePasswordRequest("admin", "bar");
+        AuthenticationRequest request = UsernamePasswordRequests.builder().setUsernameOrEmail("admin").setPassword("bar").build()
         try {
             AuthenticationResult result = application.authenticateAccount(request);
         } catch (com.stormpath.sdk.resource.ResourceException e) {
@@ -56,7 +56,7 @@ class ResourceExceptionIT extends ClientIT {
         }
 
         // authentication request for specific account store
-        request = new UsernamePasswordRequest("admin", "bar", directory);
+        request =request = UsernamePasswordRequests.builder().setUsernameOrEmail("admin").setPassword("bar").inAccountStore(directory).build()
         try {
             AuthenticationResult result = application.authenticateAccount(request);
         } catch (com.stormpath.sdk.resource.ResourceException e) {

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/DefaultUsernamePasswordRequestFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/DefaultUsernamePasswordRequestFactory.java
@@ -16,8 +16,8 @@
 package com.stormpath.sdk.servlet.filter;
 
 import com.stormpath.sdk.authc.AuthenticationRequest;
-import com.stormpath.sdk.authc.UsernamePasswordRequest;
 import com.stormpath.sdk.authc.UsernamePasswordRequestBuilder;
+import com.stormpath.sdk.authc.UsernamePasswordRequests;
 import com.stormpath.sdk.directory.AccountStore;
 import com.stormpath.sdk.lang.Assert;
 import com.stormpath.sdk.servlet.http.authc.AccountStoreResolver;
@@ -33,7 +33,7 @@ public class DefaultUsernamePasswordRequestFactory implements UsernamePasswordRe
     private AccountStoreResolver accountStoreResolver;
 
     public DefaultUsernamePasswordRequestFactory(
-        AccountStoreResolver accountStoreResolver) {
+            AccountStoreResolver accountStoreResolver) {
         Assert.notNull(accountStoreResolver, "AccountStoreResolver cannot be null.");
         this.accountStoreResolver = accountStoreResolver;
     }
@@ -46,9 +46,9 @@ public class DefaultUsernamePasswordRequestFactory implements UsernamePasswordRe
     public AuthenticationRequest createUsernamePasswordRequest(HttpServletRequest request, HttpServletResponse response,
                                                                String username, String password) {
         AccountStore accountStore =
-            getAccountStoreResolver().getAccountStore(request, response);
+                getAccountStoreResolver().getAccountStore(request, response);
 
-        UsernamePasswordRequestBuilder builder = UsernamePasswordRequest.builder()
+        UsernamePasswordRequestBuilder builder = UsernamePasswordRequests.builder()
                 .setUsernameOrEmail(username)
                 .setPassword(password)
                 .setHost(request.getRemoteHost());

--- a/extensions/spring/stormpath-spring-security/src/main/java/com/stormpath/spring/security/provider/StormpathAuthenticationProvider.java
+++ b/extensions/spring/stormpath-spring-security/src/main/java/com/stormpath/spring/security/provider/StormpathAuthenticationProvider.java
@@ -18,8 +18,7 @@ package com.stormpath.spring.security.provider;
 import com.stormpath.sdk.account.Account;
 import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.authc.AuthenticationRequest;
-import com.stormpath.sdk.authc.UsernamePasswordRequest;
-import com.stormpath.sdk.client.Client;
+import com.stormpath.sdk.authc.UsernamePasswordRequests;
 import com.stormpath.sdk.group.Group;
 import com.stormpath.sdk.group.GroupList;
 import com.stormpath.sdk.group.GroupStatus;
@@ -62,51 +61,51 @@ import java.util.Set;
  * <p/>
  * This provider implementation comes pre-configured with the following default implementations, which should suit most
  * Spring Security+Stormpath use cases:
- *
+ * <p/>
  * <table>
- *     <tr>
- *         <th>Property</th>
- *         <th>Pre-configured Implementation</th>
- *         <th>Notes</th>
- *     </tr>
- *     <tr>
- *         <td>{@link #getGroupGrantedAuthorityResolver() groupGrantedAuthorityResolver}</td>
- *         <td>{@link DefaultGroupGrantedAuthorityResolver}</td>
- *         <td>Each Stormpath Group can be represented as up to three possible Spring Security granted authorities (with
- *             1-to-1 being the default).  See the {@link DefaultGroupGrantedAuthorityResolver} JavaDoc for more info.</td>
- *     </tr>
- *     <tr>
- *         <td>{@link #getAccountGrantedAuthorityResolver() accountGrantedAuthorityResolver}</td>
- *         <td>None</td>
- *         <td>Most Spring Security+Stormpath applications should only need the above {@code DefaultGroupGrantedAuthorityResolver}
- *             when using Stormpath Groups as Spring Security granted authorities.  This authentication provider implementation
- *             already acquires the {@link com.stormpath.sdk.account.Account#getGroups() account's assigned groups} and resolves the group
- *             granted authorities via the above {@code groupGrantedAuthorityResolver}.  <b>You only need to configure this property
- *             if you need an additional way to represent an account's assigned granted authorities that cannot already be
- *             represented via Stormpath account &lt;--&gt; group associations.</td>
- *     </tr>
- *     <tr>
- *         <td>{@link #getGroupPermissionResolver() groupPermissionResolver}</td>
- *         <td>{@link GroupCustomDataPermissionResolver}</td>
- *         <td>The {@code GroupCustomDataPermissionResolver} assumes the convention that a Group's assigned permissions
- *         are stored as a nested {@code Set&lt;String&gt;} field in the
- *         {@link com.stormpath.sdk.group.Group#getCustomData() group's CustomData resource}.  See the
- *         {@link GroupCustomDataPermissionResolver} JavaDoc for more information.</td>
- *     </tr>
- *     <tr>
- *         <td>{@link #getAccountPermissionResolver() accountPermissionResolver}</td>
- *         <td>{@link AccountCustomDataPermissionResolver}</td>
- *         <td>The {@code AccountCustomDataPermissionResolver} assumes the convention that an Account's directly
- *         assigned permissions are stored as a nested {@code Set&lt;String&gt;} field in the
- *         {@link com.stormpath.sdk.account.Account#getCustomData() account's CustomData resource}.  See the
- *         {@link AccountCustomDataPermissionResolver} JavaDoc for more information.</td>
- *     </tr>
+ * <tr>
+ * <th>Property</th>
+ * <th>Pre-configured Implementation</th>
+ * <th>Notes</th>
+ * </tr>
+ * <tr>
+ * <td>{@link #getGroupGrantedAuthorityResolver() groupGrantedAuthorityResolver}</td>
+ * <td>{@link DefaultGroupGrantedAuthorityResolver}</td>
+ * <td>Each Stormpath Group can be represented as up to three possible Spring Security granted authorities (with
+ * 1-to-1 being the default).  See the {@link DefaultGroupGrantedAuthorityResolver} JavaDoc for more info.</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #getAccountGrantedAuthorityResolver() accountGrantedAuthorityResolver}</td>
+ * <td>None</td>
+ * <td>Most Spring Security+Stormpath applications should only need the above {@code DefaultGroupGrantedAuthorityResolver}
+ * when using Stormpath Groups as Spring Security granted authorities.  This authentication provider implementation
+ * already acquires the {@link com.stormpath.sdk.account.Account#getGroups() account's assigned groups} and resolves the group
+ * granted authorities via the above {@code groupGrantedAuthorityResolver}.  <b>You only need to configure this property
+ * if you need an additional way to represent an account's assigned granted authorities that cannot already be
+ * represented via Stormpath account &lt;--&gt; group associations.</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #getGroupPermissionResolver() groupPermissionResolver}</td>
+ * <td>{@link GroupCustomDataPermissionResolver}</td>
+ * <td>The {@code GroupCustomDataPermissionResolver} assumes the convention that a Group's assigned permissions
+ * are stored as a nested {@code Set&lt;String&gt;} field in the
+ * {@link com.stormpath.sdk.group.Group#getCustomData() group's CustomData resource}.  See the
+ * {@link GroupCustomDataPermissionResolver} JavaDoc for more information.</td>
+ * </tr>
+ * <tr>
+ * <td>{@link #getAccountPermissionResolver() accountPermissionResolver}</td>
+ * <td>{@link AccountCustomDataPermissionResolver}</td>
+ * <td>The {@code AccountCustomDataPermissionResolver} assumes the convention that an Account's directly
+ * assigned permissions are stored as a nested {@code Set&lt;String&gt;} field in the
+ * {@link com.stormpath.sdk.account.Account#getCustomData() account's CustomData resource}.  See the
+ * {@link AccountCustomDataPermissionResolver} JavaDoc for more information.</td>
+ * </tr>
  * </table>
  * <h4>Transitive Permissions</h4>
  * This implementation represents an Account's granted permissions as all permissions that:
  * <ol>
- *     <li>Are assigned directly to the Account itself</li>
- *     <li>Are assigned to any of the Account's assigned Groups</li>
+ * <li>Are assigned directly to the Account itself</li>
+ * <li>Are assigned to any of the Account's assigned Groups</li>
  * </ol>
  * <h4>Assigning Permissions</h4>
  * A Spring Security Authentication Provider is a read-only component - it typically does not support account/group/permission
@@ -351,11 +350,11 @@ public class StormpathAuthenticationProvider implements AuthenticationProvider {
         String username = (String) authentication.getPrincipal();
         String password = (String) authentication.getCredentials();
 
-        if (!Strings.hasText(username)){
+        if (!Strings.hasText(username)) {
             throw new AuthenticationServiceException("Login and password required");
         }
 
-        return UsernamePasswordRequest.builder().setUsernameOrEmail(username).setPassword(password).build();
+        return UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).build();
     }
 
     protected Collection<GrantedAuthority> getGrantedAuthorities(Account account) {

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/application/DefaultApplicationTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/application/DefaultApplicationTest.groovy
@@ -24,7 +24,7 @@ import com.stormpath.sdk.application.ApplicationAccountStoreMapping
 import com.stormpath.sdk.application.ApplicationAccountStoreMappingList
 import com.stormpath.sdk.application.ApplicationStatus
 import com.stormpath.sdk.authc.AuthenticationResult
-import com.stormpath.sdk.authc.UsernamePasswordRequest
+import com.stormpath.sdk.authc.UsernamePasswordRequests
 import com.stormpath.sdk.directory.AccountStore
 import com.stormpath.sdk.directory.CustomData
 import com.stormpath.sdk.directory.Directory
@@ -185,7 +185,7 @@ class DefaultApplicationTest {
         defaultBasicLoginAttempt.setType("basic")
         defaultBasicLoginAttempt.setValue("dXNlcm5hbWU6cGFzc3dvcmQ=")
 
-        def options = UsernamePasswordRequest.options().withAccount()
+        def options = UsernamePasswordRequests.options().withAccount()
          expect(internalDataStore.create((String) properties.href + "/loginAttempts", defaultBasicLoginAttempt, AuthenticationResult.class, options)).andReturn(authenticationResult02)
 
         replay internalDataStore, groupCriteria, accountCriteria, account
@@ -218,9 +218,9 @@ class DefaultApplicationTest {
 
         assertEquals(defaultApplication.sendPasswordResetEmail("some@email.com").getAccount(), account)
         assertEquals(defaultApplication.verifyPasswordResetToken("token"), account)
-        assertEquals(defaultApplication.authenticateAccount(new UsernamePasswordRequest("username", "password")), authenticationResult01)
+        assertEquals(defaultApplication.authenticateAccount(UsernamePasswordRequests.builder().setUsernameOrEmail("username").setPassword("password").build()), authenticationResult01)
 
-        def request = UsernamePasswordRequest.builder().setUsernameOrEmail("username").setPassword("password").withResponseOptions(options).build()
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail("username").setPassword("password").withResponseOptions(options).build()
         assertEquals(defaultApplication.authenticateAccount(request), authenticationResult02)
 
         verify internalDataStore, groupCriteria, accountCriteria, account
@@ -714,7 +714,7 @@ class DefaultApplicationTest {
 
         assertEquals(defaultApplication.sendPasswordResetEmail("some@email.com").getAccount(), account)
         assertEquals(defaultApplication.resetPassword("token", "myNewPassword"), account)
-        assertEquals(defaultApplication.authenticateAccount(new UsernamePasswordRequest("username", "myNewPassword")), authenticationResult, null)
+        assertEquals(defaultApplication.authenticateAccount(UsernamePasswordRequests.builder().setUsernameOrEmail("username").setPassword("myNewPassword").build()), authenticationResult, null)
 
         verify internalDataStore, account
     }

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/authc/BasicAuthenticatorTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/authc/BasicAuthenticatorTest.groovy
@@ -17,7 +17,7 @@ package com.stormpath.sdk.impl.authc
 
 import com.stormpath.sdk.authc.AuthenticationRequest
 import com.stormpath.sdk.authc.AuthenticationResult
-import com.stormpath.sdk.authc.UsernamePasswordRequest
+import com.stormpath.sdk.authc.UsernamePasswordRequests
 import com.stormpath.sdk.directory.AccountStore
 import com.stormpath.sdk.impl.ds.InternalDataStore
 import org.testng.annotations.Test
@@ -33,7 +33,7 @@ class BasicAuthenticatorTest {
     @Test
     void testNullHref() {
         def internalDataStore = createMock(InternalDataStore)
-        def request = new UsernamePasswordRequest("foo", "bar")
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail("foo").setPassword("bar").build()
 
         try {
             BasicAuthenticator basicAuthenticator = new BasicAuthenticator(internalDataStore)
@@ -70,7 +70,7 @@ class BasicAuthenticatorTest {
         def basicLoginAttempt = createStrictMock(BasicLoginAttempt)
         def authenticationResult = createStrictMock(AuthenticationResult)
 
-        def request = new UsernamePasswordRequest(username, password)
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).build()
 
         expect(internalDataStore.instantiate(BasicLoginAttempt.class)).andReturn(basicLoginAttempt);
         expect(basicLoginAttempt.setType("basic"))
@@ -97,7 +97,7 @@ class BasicAuthenticatorTest {
         def basicLoginAttempt = createStrictMock(BasicLoginAttempt)
         def authenticationResult = createStrictMock(AuthenticationResult)
 
-        def request = new UsernamePasswordRequest(username, password, (AccountStore) null)
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).build()
 
         expect(internalDataStore.instantiate(BasicLoginAttempt.class)).andReturn(basicLoginAttempt);
         expect(basicLoginAttempt.setType("basic"))
@@ -125,7 +125,7 @@ class BasicAuthenticatorTest {
         def basicLoginAttempt = createStrictMock(BasicLoginAttempt)
         def authenticationResult = createStrictMock(AuthenticationResult)
 
-        def request = new UsernamePasswordRequest(username, password, accountStore)
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).inAccountStore(accountStore).build()
 
         expect(internalDataStore.instantiate(BasicLoginAttempt.class)).andReturn(basicLoginAttempt);
         expect(basicLoginAttempt.setType("basic"))
@@ -154,8 +154,8 @@ class BasicAuthenticatorTest {
         def basicLoginAttempt = createStrictMock(BasicLoginAttempt)
         def authenticationResult = createStrictMock(AuthenticationResult)
 
-        def options = UsernamePasswordRequest.options().withAccount()
-        def request = UsernamePasswordRequest.builder().setUsernameOrEmail(username).setPassword(password).withResponseOptions(options).build()
+        def options = UsernamePasswordRequests.options().withAccount()
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail(username).setPassword(password).withResponseOptions(options).build()
 
         expect(internalDataStore.instantiate(BasicLoginAttempt.class)).andReturn(basicLoginAttempt);
         expect(basicLoginAttempt.setType("basic"))

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/authc/UsernamePasswordRequestBuilderTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/authc/UsernamePasswordRequestBuilderTest.groovy
@@ -16,11 +16,11 @@
 package com.stormpath.sdk.impl.authc
 
 import com.stormpath.sdk.authc.BasicAuthenticationOptions
-import com.stormpath.sdk.authc.UsernamePasswordRequest
+import com.stormpath.sdk.authc.UsernamePasswordRequests
 import com.stormpath.sdk.directory.Directory
 import org.testng.annotations.Test
 
-import static org.easymock.EasyMock.*
+import static org.easymock.EasyMock.createMock
 import static org.testng.Assert.*
 
 /**
@@ -32,7 +32,7 @@ class UsernamePasswordRequestBuilderTest {
     void testAllProperties() {
         def accountStore = createMock(Directory)
         def options = createMock(BasicAuthenticationOptions)
-        def authenticationRequest = UsernamePasswordRequest.builder()
+        def authenticationRequest = UsernamePasswordRequests.builder()
                 .setUsernameOrEmail("usernameOrEmail")
                 .setPassword("myPassword123!")
                 .setHost("http://myHost.com")
@@ -50,30 +50,30 @@ class UsernamePasswordRequestBuilderTest {
     @Test
     void testNullChecks() {
         try {
-            UsernamePasswordRequest.builder().build()
+            UsernamePasswordRequests.builder().build()
             fail("Should have thrown");
-        } catch (IllegalStateException e){
+        } catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "usernameOrEmail has not been set. It is a required attribute.")
         }
 
         try {
-            UsernamePasswordRequest.builder().setUsernameOrEmail("someFooUsername").setHost(null)
+            UsernamePasswordRequests.builder().setUsernameOrEmail("someFooUsername").setHost(null)
             fail("Should have thrown");
-        } catch (IllegalArgumentException e){
+        } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "host cannot be null.")
         }
 
         try {
-            UsernamePasswordRequest.builder().setUsernameOrEmail("someFooUsername").inAccountStore(null)
+            UsernamePasswordRequests.builder().setUsernameOrEmail("someFooUsername").inAccountStore(null)
             fail("Should have thrown");
-        } catch (IllegalArgumentException e){
+        } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "accountStore cannot be null.")
         }
 
         try {
-            UsernamePasswordRequest.builder().setUsernameOrEmail("someFooUsername").withResponseOptions(null)
+            UsernamePasswordRequests.builder().setUsernameOrEmail("someFooUsername").withResponseOptions(null)
             fail("Should have thrown");
-        } catch (IllegalArgumentException e){
+        } catch (IllegalArgumentException e) {
             assertEquals(e.getMessage(), "options cannot be null.")
         }
     }

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/authc/UsernamePasswordRequestsTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/authc/UsernamePasswordRequestsTest.groovy
@@ -1,0 +1,67 @@
+package com.stormpath.sdk.impl.authc
+
+import com.stormpath.sdk.authc.UsernamePasswordRequests
+import com.stormpath.sdk.directory.AccountStore
+import org.testng.annotations.Test
+
+import static org.easymock.EasyMock.*
+import static org.testng.Assert.*
+
+/**
+ * @since 1.0.RC9
+ */
+class UsernamePasswordRequestsTest {
+
+    @Test
+    void testBuilder() {
+        def builder = UsernamePasswordRequests.builder();
+        assertTrue(builder instanceof DefaultUsernamePasswordRequestBuilder)
+    }
+
+    @Test
+    void testOptions() {
+        def options = UsernamePasswordRequests.options();
+        assertTrue(options instanceof DefaultBasicAuthenticationOptions)
+    }
+
+    @Test
+    void testAccountStore() {
+
+        def accountStore = createMock(AccountStore)
+
+        //Password String
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail("username").setPassword("passwd").build()
+        assertNull request.getAccountStore()
+
+        request = UsernamePasswordRequests.builder().setUsernameOrEmail("username").setPassword("passwd").setHost("someHost").build()
+        assertEquals(request.getAccountStore(), null)
+
+        request = UsernamePasswordRequests.builder().setUsernameOrEmail("username").setPassword("passwd").inAccountStore(accountStore).build()
+        assertSame(request.getAccountStore(), accountStore)
+
+        //Password char[]
+        request = UsernamePasswordRequests.builder().setUsernameOrEmail("username").setPassword("passwd".toCharArray()).build()
+        assertEquals(request.getAccountStore(), null)
+
+        request = UsernamePasswordRequests.builder().setUsernameOrEmail("username").setPassword("passwd".toCharArray()).setHost("someHost").build()
+        assertSame(request.getAccountStore(), null)
+
+        request = UsernamePasswordRequests.builder().setUsernameOrEmail("username").setPassword("passwd".toCharArray()).inAccountStore(accountStore).build()
+        assertSame(request.getAccountStore(), accountStore)
+    }
+
+    @Test
+    void testClear() {
+
+        def accountStore = createMock(AccountStore)
+
+        def request = UsernamePasswordRequests.builder().setUsernameOrEmail("username").setPassword("password").setHost("foo").inAccountStore(accountStore).build()
+
+        request.clear()
+
+        assertNull request.getAccountStore()
+        assertNull request.getCredentials()
+        assertNull request.getPrincipals()
+        assertNull request.getHost()
+    }
+}


### PR DESCRIPTION
Fixes #408 

Alternative class now reflects the same pattern we use elsewhere in the SDK for utility classes (e.g. `Accounts`, `Directories`, `Applications`, etc).