### PR TITLE
Updated code to reflect changes that breaks the use of SAML with ID Site.

### DIFF
--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/idsite/IdSiteReplyIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/idsite/IdSiteReplyIT.groovy
@@ -26,6 +26,7 @@ import com.stormpath.sdk.http.HttpRequests
 import com.stormpath.sdk.idsite.AccountResult
 import com.stormpath.sdk.impl.http.QueryString
 import com.stormpath.sdk.impl.jwt.signer.DefaultJwtSigner
+import com.stormpath.sdk.lang.Assert
 import com.stormpath.sdk.lang.Strings
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
@@ -181,16 +182,14 @@ class IdSiteReplyIT extends ClientIT {
     }
 
     String buildSsoResponse(String apiKeyId, String apiKeySecret, String issuer, int ttl, String state, IdSiteResultStatus status) {
+        Assert.hasText(apiKeyId)
+        Assert.hasText(apiKeySecret)
 
         def expired = (System.currentTimeMillis() / 1000) + ttl
 
         def nonce = UUID.randomUUID().toString()
 
         def map = [sub: account.href, isNewSub: false, exp: expired, irt: nonce, status: status]
-
-        if (Strings.hasText(apiKeyId)) {
-            map.aud = apiKeyId
-        }
 
         if (Strings.hasText(issuer)) {
             map.iss = issuer
@@ -200,7 +199,7 @@ class IdSiteReplyIT extends ClientIT {
             map.state = state
         }
 
-        DefaultJwtSigner signer = new DefaultJwtSigner(apiKeySecret)
+        DefaultJwtSigner signer = new DefaultJwtSigner(apiKeyId, apiKeySecret)
 
         signer.sign(objectMapper.writeValueAsString(map))
     }

--- a/extensions/oauth/src/main/java/com/stormpath/sdk/impl/oauth/authc/AccessTokenRequestAuthenticator.java
+++ b/extensions/oauth/src/main/java/com/stormpath/sdk/impl/oauth/authc/AccessTokenRequestAuthenticator.java
@@ -79,7 +79,7 @@ public class AccessTokenRequestAuthenticator {
     public AccessTokenRequestAuthenticator(InternalDataStore internalDataStore) {
         dataStore = internalDataStore;
 
-        jwtSigner = new DefaultJwtSigner(dataStore.getApiKey().getSecret());
+        jwtSigner = new DefaultJwtSigner(dataStore.getApiKey().getId(), dataStore.getApiKey().getSecret());
     }
 
     public AccessTokenResult authenticate(Application application, AccessTokenAuthenticationRequest request) {

--- a/impl/src/main/java/com/stormpath/sdk/impl/idsite/DefaultIdSiteCallbackHandler.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/idsite/DefaultIdSiteCallbackHandler.java
@@ -108,12 +108,8 @@ public class DefaultIdSiteCallbackHandler implements IdSiteCallbackHandler {
 
         String apiKeyId;
 
-        if (isError(jsonPayload)) {
-            Map jsonHeader = jwtWrapper.getJsonHeaderAsMap();
-            apiKeyId = getRequiredValue(jsonHeader, KEY_ID);
-        } else {
-            apiKeyId = getRequiredValue(jsonPayload, Claims.AUDIENCE);
-        }
+        Map jsonHeader = jwtWrapper.getJsonHeaderAsMap();
+        apiKeyId = getRequiredValue(jsonHeader, KEY_ID);
 
         getJwtSignatureValidator(apiKeyId).validate(jwtWrapper);
 

--- a/impl/src/main/java/com/stormpath/sdk/impl/jwt/JwtSignatureValidator.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/jwt/JwtSignatureValidator.java
@@ -32,7 +32,7 @@ public class JwtSignatureValidator {
 
         Assert.notNull(apiKey, "apiKey cannot be null.");
 
-        jwtSigner = new DefaultJwtSigner(apiKey.getSecret());
+        jwtSigner = new DefaultJwtSigner(apiKey.getId(), apiKey.getSecret());
     }
 
     /**

--- a/impl/src/main/java/com/stormpath/sdk/impl/jwt/signer/DefaultJwtSigner.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/jwt/signer/DefaultJwtSigner.java
@@ -29,24 +29,22 @@ public class DefaultJwtSigner implements JwtSigner {
 
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
-    private static final String BASE64_URL_JWT_SIGN_HEADER;
+    private final String BASE64_URL_JWT_SIGN_HEADER;
 
-    public static final String JWT_SIGN_HEADER;
+    public final String JWT_SIGN_HEADER;
 
     private static final char JWT_TOKEN_SEPARATOR = '.';
 
     private static final String SHA256_ALGORITHM = "HmacSHA256";
 
-    static {
-        JWT_SIGN_HEADER = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
-        BASE64_URL_JWT_SIGN_HEADER = Base64.encodeBase64URLSafeString(JWT_SIGN_HEADER.getBytes(UTF_8));
-    }
-
     private final HmacGenerator sha256HmacGenerator;
 
     private final byte[] signingKey;
+    
+    public DefaultJwtSigner(String kid, String signingKey) {
+        JWT_SIGN_HEADER = "{\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"" + kid + "\"}";
 
-    public DefaultJwtSigner(String signingKey) {
+        BASE64_URL_JWT_SIGN_HEADER = Base64.encodeBase64URLSafeString(JWT_SIGN_HEADER.getBytes(UTF_8));
 
         this.signingKey = signingKey.getBytes(UTF_8);
 
@@ -61,9 +59,12 @@ public class DefaultJwtSigner implements JwtSigner {
 
         String signature = calculateSignature(BASE64_URL_JWT_SIGN_HEADER, base64UrlJsonPayload);
 
-        return new StringBuilder(BASE64_URL_JWT_SIGN_HEADER).append(JWT_TOKEN_SEPARATOR)
-                                                            .append(base64UrlJsonPayload).append(JWT_TOKEN_SEPARATOR)
-                                                            .append(signature).toString();
+        return new StringBuilder(BASE64_URL_JWT_SIGN_HEADER)
+            .append(JWT_TOKEN_SEPARATOR)
+            .append(base64UrlJsonPayload)
+            .append(JWT_TOKEN_SEPARATOR)
+            .append(signature)
+            .toString();
     }
 
     @Override

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/idsite/DefaultIdSiteCallbackHandlerTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/idsite/DefaultIdSiteCallbackHandlerTest.groovy
@@ -46,64 +46,64 @@ class DefaultIdSiteCallbackHandlerTest {
 
     @Test
     void testRegisteredListener() {
-        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1w" +
-                "YXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIi" +
-                "wiYXVkIjoiMkVWNzBBSFJUWUYwSk9BN09FRk8zU00yOSIsImV4cCI6MjUwMjQ2NjY1MDAwLCJpYXQiOjE0MDcxOTg1NTAsImp0aSI6" +
-                "IjQzNnZra0hnazF4MzA1N3BDUHFUYWgiLCJpcnQiOiIxZDAyZDMzNS1mYmZjLTRlYTgtYjgzNi04NWI5ZTJhNmYyYTAiLCJpc05ld1" +
-                "N1YiI6ZmFsc2UsInN0YXR1cyI6IlJFR0lTVEVSRUQifQ.4_yCiF6Cik2wep3iwyinTTcn5GHAEvCbIezO1aA5Kkk"
+        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjJFVjcwQUhSVFlGMEpPQTdPRUZPM1NNMjkifQ.eyJpc3" +
+                "MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1wYXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92" +
+                "MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIiwiZXhwIjoyNTAyNDY2NjUwMDAsImlhdCI6MTQwNzE5ODU1MCwianRpIj" +
+                "oiNDM2dmtrSGdrMXgzMDU3cENQcVRhaCIsImlydCI6IjFkMDJkMzM1LWZiZmMtNGVhOC1iODM2LTg1YjllMmE2ZjJhMCIsImlzTmV3" +
+                "U3ViIjpmYWxzZSwic3RhdHVzIjoiUkVHSVNURVJFRCJ9.0n-Sp5zDtiOIJ_Zq6IYdrDHoU3i95XPKhlH-2n9ALdg"
         testListener(jwtResponse, IdSiteResultStatus.REGISTERED, IdSiteResultListenerType.SINGLE)
     }
 
     @Test
     void testAuthenticatedListener() {
-        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1w" +
-                "YXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIi" +
-                "wiYXVkIjoiMkVWNzBBSFJUWUYwSk9BN09FRk8zU00yOSIsImV4cCI6MjUwMjQ2NjY1MDAwLCJpYXQiOjE0MDcxOTg1NTAsImp0aSI6" +
-                "IjQzNnZra0hnazF4MzA1N3BDUHFUYWgiLCJpcnQiOiIxZDAyZDMzNS1mYmZjLTRlYTgtYjgzNi04NWI5ZTJhNmYyYTAiLCJpc05ld1" +
-                "N1YiI6ZmFsc2UsInN0YXR1cyI6IkFVVEhFTlRJQ0FURUQifQ.rpp0lsM1JDFeqkrOdwrtYOB1aitnLwhJuH3iaeuLIXY"
+        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjJFVjcwQUhSVFlGMEpPQTdPRUZPM1NNMjkifQ.eyJpc3" +
+                "MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1wYXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92" +
+                "MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIiwiZXhwIjoyNTAyNDY2NjUwMDAsImlhdCI6MTQwNzE5ODU1MCwianRpIj" +
+                "oiNDM2dmtrSGdrMXgzMDU3cENQcVRhaCIsImlydCI6IjFkMDJkMzM1LWZiZmMtNGVhOC1iODM2LTg1YjllMmE2ZjJhMCIsImlzTmV3" +
+                "U3ViIjpmYWxzZSwic3RhdHVzIjoiQVVUSEVOVElDQVRFRCJ9.jR_T2G0obYuVIf-Gxer5pCieglfzwdWfNoMn505-hEw"
         testListener(jwtResponse, IdSiteResultStatus.AUTHENTICATED, IdSiteResultListenerType.SINGLE)
     }
 
     @Test
     void testLogoutListener() {
-        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1w" +
-                "YXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIi" +
-                "wiYXVkIjoiMkVWNzBBSFJUWUYwSk9BN09FRk8zU00yOSIsImV4cCI6MjUwMjQ2NjY1MDAwLCJpYXQiOjE0MDcxOTg1NTAsImp0aSI6" +
-                "IjQzNnZra0hnazF4MzA1N3BDUHFUYWgiLCJpcnQiOiIxZDAyZDMzNS1mYmZjLTRlYTgtYjgzNi04NWI5ZTJhNmYyYTAiLCJpc05ld1" +
-                "N1YiI6ZmFsc2UsInN0YXR1cyI6IkxPR09VVCJ9.T6ClI4znHCElk1gMQoBpVvE9Jc5Vf4BEjrQ0IWvKYIc"
+        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjJFVjcwQUhSVFlGMEpPQTdPRUZPM1NNMjkifQ.eyJpc3" +
+                "MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1wYXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92" +
+                "MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIiwiZXhwIjoyNTAyNDY2NjUwMDAsImlhdCI6MTQwNzE5ODU1MCwianRpIj" +
+                "oiNDM2dmtrSGdrMXgzMDU3cENQcVRhaCIsImlydCI6IjFkMDJkMzM1LWZiZmMtNGVhOC1iODM2LTg1YjllMmE2ZjJhMCIsImlzTmV3" +
+                "U3ViIjpmYWxzZSwic3RhdHVzIjoiTE9HT1VUIn0.eQJAg2ils97GdtokcaK4T98CwfizM7ZCmuTqew9gf2Y"
         testListener(jwtResponse, IdSiteResultStatus.LOGOUT, IdSiteResultListenerType.SINGLE)
     }
 
     /* @since 1.0.RC7.3 */
     @Test
     void testRegisteredListenerMulti() {
-        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1w" +
-                "YXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIi" +
-                "wiYXVkIjoiMkVWNzBBSFJUWUYwSk9BN09FRk8zU00yOSIsImV4cCI6MjUwMjQ2NjY1MDAwLCJpYXQiOjE0MDcxOTg1NTAsImp0aSI6" +
-                "IjQzNnZra0hnazF4MzA1N3BDUHFUYWgiLCJpcnQiOiIxZDAyZDMzNS1mYmZjLTRlYTgtYjgzNi04NWI5ZTJhNmYyYTAiLCJpc05ld1" +
-                "N1YiI6ZmFsc2UsInN0YXR1cyI6IlJFR0lTVEVSRUQifQ.4_yCiF6Cik2wep3iwyinTTcn5GHAEvCbIezO1aA5Kkk"
+        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjJFVjcwQUhSVFlGMEpPQTdPRUZPM1NNMjkifQ.eyJpc3" +
+                "MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1wYXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92" +
+                "MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIiwiZXhwIjoyNTAyNDY2NjUwMDAsImlhdCI6MTQwNzE5ODU1MCwianRpIj" +
+                "oiNDM2dmtrSGdrMXgzMDU3cENQcVRhaCIsImlydCI6IjFkMDJkMzM1LWZiZmMtNGVhOC1iODM2LTg1YjllMmE2ZjJhMCIsImlzTmV3" +
+                "U3ViIjpmYWxzZSwic3RhdHVzIjoiUkVHSVNURVJFRCJ9.0n-Sp5zDtiOIJ_Zq6IYdrDHoU3i95XPKhlH-2n9ALdg"
         testListener(jwtResponse, IdSiteResultStatus.REGISTERED, IdSiteResultListenerType.MULTI)
     }
 
     /* @since 1.0.RC7.3 */
     @Test
     void testAuthenticatedListenerMulti() {
-        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1w" +
-                "YXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIi" +
-                "wiYXVkIjoiMkVWNzBBSFJUWUYwSk9BN09FRk8zU00yOSIsImV4cCI6MjUwMjQ2NjY1MDAwLCJpYXQiOjE0MDcxOTg1NTAsImp0aSI6" +
-                "IjQzNnZra0hnazF4MzA1N3BDUHFUYWgiLCJpcnQiOiIxZDAyZDMzNS1mYmZjLTRlYTgtYjgzNi04NWI5ZTJhNmYyYTAiLCJpc05ld1" +
-                "N1YiI6ZmFsc2UsInN0YXR1cyI6IkFVVEhFTlRJQ0FURUQifQ.rpp0lsM1JDFeqkrOdwrtYOB1aitnLwhJuH3iaeuLIXY"
+        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjJFVjcwQUhSVFlGMEpPQTdPRUZPM1NNMjkifQ.eyJpc3" +
+                "MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1wYXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92" +
+                "MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIiwiZXhwIjoyNTAyNDY2NjUwMDAsImlhdCI6MTQwNzE5ODU1MCwianRpIj" +
+                "oiNDM2dmtrSGdrMXgzMDU3cENQcVRhaCIsImlydCI6IjFkMDJkMzM1LWZiZmMtNGVhOC1iODM2LTg1YjllMmE2ZjJhMCIsImlzTmV3" +
+                "U3ViIjpmYWxzZSwic3RhdHVzIjoiQVVUSEVOVElDQVRFRCJ9.jR_T2G0obYuVIf-Gxer5pCieglfzwdWfNoMn505-hEw"
         testListener(jwtResponse, IdSiteResultStatus.AUTHENTICATED, IdSiteResultListenerType.MULTI)
     }
 
     /* @since 1.0.RC7.3 */
     @Test
     void testLogoutListenerMulti() {
-        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1w" +
-                "YXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIi" +
-                "wiYXVkIjoiMkVWNzBBSFJUWUYwSk9BN09FRk8zU00yOSIsImV4cCI6MjUwMjQ2NjY1MDAwLCJpYXQiOjE0MDcxOTg1NTAsImp0aSI6" +
-                "IjQzNnZra0hnazF4MzA1N3BDUHFUYWgiLCJpcnQiOiIxZDAyZDMzNS1mYmZjLTRlYTgtYjgzNi04NWI5ZTJhNmYyYTAiLCJpc05ld1" +
-                "N1YiI6ZmFsc2UsInN0YXR1cyI6IkxPR09VVCJ9.T6ClI4znHCElk1gMQoBpVvE9Jc5Vf4BEjrQ0IWvKYIc"
+        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjJFVjcwQUhSVFlGMEpPQTdPRUZPM1NNMjkifQ.eyJpc3" +
+                "MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1wYXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92" +
+                "MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIiwiZXhwIjoyNTAyNDY2NjUwMDAsImlhdCI6MTQwNzE5ODU1MCwianRpIj" +
+                "oiNDM2dmtrSGdrMXgzMDU3cENQcVRhaCIsImlydCI6IjFkMDJkMzM1LWZiZmMtNGVhOC1iODM2LTg1YjllMmE2ZjJhMCIsImlzTmV3" +
+                "U3ViIjpmYWxzZSwic3RhdHVzIjoiTE9HT1VUIn0.eQJAg2ils97GdtokcaK4T98CwfizM7ZCmuTqew9gf2Y"
         testListener(jwtResponse, IdSiteResultStatus.LOGOUT, IdSiteResultListenerType.MULTI)
     }
 
@@ -180,11 +180,11 @@ class DefaultIdSiteCallbackHandlerTest {
     }
 
     private void testNoListener(IdSiteResultListenerType idSiteResultListenerType) {
-        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1w" +
-                "YXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIi" +
-                "wiYXVkIjoiMkVWNzBBSFJUWUYwSk9BN09FRk8zU00yOSIsImV4cCI6MjUwMjQ2NjY1MDAwLCJpYXQiOjE0MDcxOTg1NTAsImp0aSI6" +
-                "IjQzNnZra0hnazF4MzA1N3BDUHFUYWgiLCJpcnQiOiIxZDAyZDMzNS1mYmZjLTRlYTgtYjgzNi04NWI5ZTJhNmYyYTAiLCJpc05ld1" +
-                "N1YiI6ZmFsc2UsInN0YXR1cyI6IlJFR0lTVEVSRUQifQ.4_yCiF6Cik2wep3iwyinTTcn5GHAEvCbIezO1aA5Kkk"
+        String jwtResponse = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjJFVjcwQUhSVFlGMEpPQTdPRUZPM1NNMjkifQ.eyJpc3" +
+                "MiOiJodHRwczovL3N0dXJkeS1zaGllbGQuaWQuc3Rvcm1wYXRoLmlvIiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92" +
+                "MS9hY2NvdW50cy83T3JhOEtmVkRFSVFQMzhLenJZZEFzIiwiZXhwIjoyNTAyNDY2NjUwMDAsImlhdCI6MTQwNzE5ODU1MCwianRpIj" +
+                "oiNDM2dmtrSGdrMXgzMDU3cENQcVRhaCIsImlydCI6IjFkMDJkMzM1LWZiZmMtNGVhOC1iODM2LTg1YjllMmE2ZjJhMCIsImlzTmV3" +
+                "U3ViIjpmYWxzZSwic3RhdHVzIjoiUkVHSVNURVJFRCJ9.0n-Sp5zDtiOIJ_Zq6IYdrDHoU3i95XPKhlH-2n9ALdg"
 
         def apiKey = ApiKeys.builder().setId('2EV70AHRTYF0JOA7OEFO3SM29').setSecret('goPUHQMkS4dlKwl5wtbNd91I+UrRehCsEDJrIrMruK8').build()
         def requestExecutor = createStrictMock(RequestExecutor)


### PR DESCRIPTION
Resolves #554 

Namely, looking for kid in header and not requiring aud claim in payload. Updated tests to shift aud claim in payload to kid claim in header.