### PR TITLE
Fix disabled refresh token

### DIFF
--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
@@ -17,11 +17,7 @@ package com.stormpath.sdk.impl.oauth;
 
 import com.stormpath.sdk.impl.ds.InternalDataStore;
 import com.stormpath.sdk.lang.Assert;
-import com.stormpath.sdk.lang.Strings;
 import com.stormpath.sdk.oauth.AccessToken;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
 
 import java.util.Map;
 
@@ -44,23 +40,9 @@ public class DefaultAccessToken extends AbstractBaseOauth2Token implements Acces
      * @since 1.0.RC8.3
      */
     private void ensureAccessToken() {
-        if(isMaterialized()) {
-            try {
-                Claims claims = Jwts.parser()
-                        .setSigningKey(getDataStore().getApiKey().getSecret().getBytes("UTF-8"))
-                        .parseClaimsJws(getString(JWT)).getBody();
-
-                // token *must* have an rti claim to be an access_token
-                // otherwise, it may be a refresh_token trying to be passed off as an access_token
-                Assert.isTrue(Strings.hasText((String) claims.get("rti")));
-            } catch (Exception e) {
-                throw new JwtException("JWT failed validation; it cannot be trusted.");
-            }
-        } else {
             String href = getStringProperty(HREF_PROP_NAME);
             if (href != null) {
                 Assert.isTrue(href.contains("/accessTokens/"), "href does not belong to an access token.");
-            }
         }
     }
 }

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultAccessToken.java
@@ -26,6 +26,8 @@ import java.util.Map;
  */
 public class DefaultAccessToken extends AbstractBaseOauth2Token implements AccessToken {
 
+    protected final static String ACCESS_TOKEN_PATH = "/accessTokens/";
+
     public DefaultAccessToken(InternalDataStore dataStore, Map<String, Object> properties) {
         super(dataStore, properties);
         ensureAccessToken();
@@ -42,7 +44,7 @@ public class DefaultAccessToken extends AbstractBaseOauth2Token implements Acces
     private void ensureAccessToken() {
             String href = getStringProperty(HREF_PROP_NAME);
             if (href != null) {
-                Assert.isTrue(href.contains("/accessTokens/"), "href does not belong to an access token.");
+                Assert.isTrue(href.contains(ACCESS_TOKEN_PATH), "href does not belong to an access token.");
         }
     }
 }

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultAccessTokenTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultAccessTokenTest.groovy
@@ -67,9 +67,6 @@ class DefaultAccessTokenTest {
         def internalDataStore = createStrictMock(InternalDataStore)
         def apiKey = createStrictMock(ApiKey)
 
-        expect(internalDataStore.getApiKey()).andReturn(apiKey)
-        expect(apiKey.getSecret()).andReturn(secret)
-
         replay internalDataStore, apiKey
 
         def defaultAccessToken = new DefaultAccessToken(internalDataStore, properties)
@@ -116,9 +113,6 @@ class DefaultAccessTokenTest {
         def internalDataStore = createStrictMock(InternalDataStore)
         def apiKey = createStrictMock(ApiKey)
 
-        expect(apiKey.getSecret()).andReturn(secret)
-
-        expect(internalDataStore.getApiKey()).andReturn(apiKey)
         expect(internalDataStore.instantiate(Tenant, properties.tenant)).andReturn(new DefaultTenant(internalDataStore, properties.tenant))
         expect(internalDataStore.instantiate(Account, properties.account)).andReturn(new DefaultAccount(internalDataStore, properties.account))
         expect(internalDataStore.instantiate(Application, properties.application)).andReturn(new DefaultApplication(internalDataStore, properties.application))
@@ -139,40 +133,6 @@ class DefaultAccessTokenTest {
 
         def application = defaultAccessToken.getApplication()
         assertTrue(application instanceof Application && application.getHref().equals(properties.application.href))
-    }
-
-    /* @since 1.0.RC8.3 */
-    @Test
-    void testInvalidAccessToken() {
-        def secret = "a_very_secret_key"
-        def href = "https://api.stormpath.com/v1/accessTokens/5hFj6FUwNb28OQrp93phPP"
-
-        // no rti claim means it's not a valid access token
-        String jwt = Jwts.builder()
-            .setSubject(href)
-            .signWith(SignatureAlgorithm.HS256, secret.getBytes("UTF-8"))
-            .compact();
-
-        def properties = [
-            href: href,
-            jwt: jwt
-        ]
-
-        def internalDataStore = createStrictMock(InternalDataStore)
-        def apiKey = createStrictMock(ApiKey)
-
-        expect(apiKey.getSecret()).andReturn(secret)
-        expect(internalDataStore.getApiKey()).andReturn(apiKey)
-
-        replay internalDataStore, apiKey
-
-        try {
-            new DefaultAccessToken(internalDataStore, properties)
-            fail("should have thrown")
-        } catch (Exception e) {
-            def message = e.getMessage()
-            assertTrue message.equals("JWT failed validation; it cannot be trusted.")
-        }
     }
 
     /* @since 1.0.RC8.3 */

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultAccessTokenTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultAccessTokenTest.groovy
@@ -137,6 +137,35 @@ class DefaultAccessTokenTest {
 
     /* @since 1.0.RC8.3 */
     @Test
+    void testInvalidAccessToken() {
+        def secret = "a_very_secret_key"
+        def href = "https://api.stormpath.com/v1/refreshTokens/5hFj6FUwNb28OQrp93phPP"
+
+        String jwt = Jwts.builder()
+            .setSubject(href)
+            .signWith(SignatureAlgorithm.HS256, secret.getBytes("UTF-8"))
+            .compact();
+
+        def properties = [
+            href: href,
+            jwt: jwt
+        ]
+
+        def internalDataStore = createStrictMock(InternalDataStore)
+
+        replay internalDataStore
+
+        try {
+            new DefaultAccessToken(internalDataStore, properties)
+            fail("should have thrown")
+        } catch (Exception e) {
+            def message = e.getMessage()
+            assertTrue message.equals("href does not belong to an access token.")
+        }
+    }
+
+    /* @since 1.0.RC8.3 */
+    @Test
     void testValidAccessToken() {
         def secret = "a_very_secret_key"
         def href = "https://api.stormpath.com/v1/accessTokens/5hFj6FUwNb28OQrp93phPP"


### PR DESCRIPTION
- Token revocation listener does not check now whether the jwt corresponds to an access token or not. It just always deletes the access token. It however does check whether there is an associated refresh token to be deleted or not.
- When an access token is constructed we do not check inside the jwt any longer. We only check the href now

Resolves #547