### PR TITLE
Change YamlPropertiesSource to set lists as a comma-delimited value

### DIFF
--- a/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/config/web.stormpath.properties
+++ b/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/config/web.stormpath.properties
@@ -36,8 +36,7 @@ stormpath.web.refreshTokenCookie.httpOnly = true
 stormpath.web.refreshTokenCookie.secure =
 stormpath.web.refreshTokenCookie.path =
 stormpath.web.refreshTokenCookie.domain =
-stormpath.web.produces[0] = application/json
-stormpath.web.produces[1] = text/html
+stormpath.web.produces = application/json,text/html
 stormpath.web.register.enabled = true
 # The context-relative path to the register ('new user') view:
 stormpath.web.register.uri = /register

--- a/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/config/web.stormpath.properties
+++ b/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/config/web.stormpath.properties
@@ -85,13 +85,7 @@ stormpath.web.register.form.fields.confirmPassword.label = Confirm Password
 stormpath.web.register.form.fields.confirmPassword.placeholder = Confirm Password
 stormpath.web.register.form.fields.confirmPassword.required = true
 stormpath.web.register.form.fields.confirmPassword.type = password
-stormpath.web.register.form.fieldOrder[0] = username
-stormpath.web.register.form.fieldOrder[1] = givenName
-stormpath.web.register.form.fieldOrder[2] = middleName
-stormpath.web.register.form.fieldOrder[3] = surname
-stormpath.web.register.form.fieldOrder[4] = email
-stormpath.web.register.form.fieldOrder[5] = password
-stormpath.web.register.form.fieldOrder[6] = confirmPassword
+stormpath.web.register.form.fieldOrder = username,givenName,middleName,surname,email,password,confirmPassword
 stormpath.web.register.view = register
 # If verify is enabled, the login view will show a link to to a page where users will be able to have the account
 # verification email re-sent to them.
@@ -123,8 +117,7 @@ stormpath.web.login.form.fields.password.label = Password
 stormpath.web.login.form.fields.password.placeholder = Password
 stormpath.web.login.form.fields.password.required = true
 stormpath.web.login.form.fields.password.type = password
-stormpath.web.login.form.fieldOrder[0] = login
-stormpath.web.login.form.fieldOrder[1] = password
+stormpath.web.login.form.fieldOrder = login,password
 stormpath.web.logout.enabled = true
 # The context-relative path that will log out the user if visited:
 stormpath.web.logout.uri = /logout

--- a/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -528,16 +528,10 @@
       "description": ""
     },
     {
-      "name": "stormpath.web.produces[0]",
-      "type": "java.lang.String",
+      "name": "stormpath.web.produces",
+      "type": "java.lang.String[]",
       "description": "",
       "defaultValue": "application/json"
-    },
-    {
-      "name": "stormpath.web.produces[1]",
-      "type": "java.lang.String",
-      "description": "",
-      "defaultValue": "text/html"
     },
     {
       "name": "stormpath.web.register.autoLogin",

--- a/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -792,46 +792,10 @@
       "defaultValue": "password"
     },
     {
-      "name": "stormpath.web.register.form.fieldOrder[0]",
-      "type": "java.lang.String",
+      "name": "stormpath.web.register.form.fieldOrder",
+      "type": "java.lang.String[]",
       "description": "",
       "defaultValue": "username"
-    },
-    {
-      "name": "stormpath.web.register.form.fieldOrder[1]",
-      "type": "java.lang.String",
-      "description": "",
-      "defaultValue": "givenName"
-    },
-    {
-      "name": "stormpath.web.register.form.fieldOrder[2]",
-      "type": "java.lang.String",
-      "description": "",
-      "defaultValue": "middleName"
-    },
-    {
-      "name": "stormpath.web.register.form.fieldOrder[3]",
-      "type": "java.lang.String",
-      "description": "",
-      "defaultValue": "surname"
-    },
-    {
-      "name": "stormpath.web.register.form.fieldOrder[4]",
-      "type": "java.lang.String",
-      "description": "",
-      "defaultValue": "email"
-    },
-    {
-      "name": "stormpath.web.register.form.fieldOrder[5]",
-      "type": "java.lang.String",
-      "description": "",
-      "defaultValue": "password"
-    },
-    {
-      "name": "stormpath.web.register.form.fieldOrder[6]",
-      "type": "java.lang.String",
-      "description": "",
-      "defaultValue": "confirmPassword"
     },
     {
       "name": "stormpath.web.login.form.fields.login.enabled",
@@ -906,16 +870,10 @@
       "defaultValue": "password"
     },
     {
-      "name": "stormpath.web.login.form.fieldOrder[0]",
-      "type": "java.lang.String",
+      "name": "stormpath.web.login.form.fieldOrder",
+      "type": "java.lang.String[]",
       "description": "",
       "defaultValue": "login"
-    },
-    {
-      "name": "stormpath.web.login.form.fieldOrder[1]",
-      "type": "java.lang.String",
-      "description": "",
-      "defaultValue": "password"
     },
     {
       "name": "stormpath.web.changePassword.autoLogin",

--- a/impl/src/main/java/com/stormpath/sdk/impl/config/YAMLPropertiesSource.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/config/YAMLPropertiesSource.java
@@ -11,7 +11,6 @@ import org.yaml.snakeyaml.Yaml;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -85,11 +84,7 @@ public class YAMLPropertiesSource implements PropertiesSource {
                 // Need a compound key
                 @SuppressWarnings("unchecked")
                 Collection<Object> collection = (Collection<Object>) value;
-                int count = 0;
-                for (Object object : collection) {
-                    buildFlattenedMap(result,
-                            Collections.singletonMap("[" + (count++) + "]", object), key);
-                }
+                result.put(key, Strings.collectionToCommaDelimitedString(collection));
             }
             else {
                 result.put(key, value != null ? String.valueOf(value) : "");

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/config/JSONPropertiesSourceTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/config/JSONPropertiesSourceTest.groovy
@@ -27,6 +27,18 @@ class JSONPropertiesSourceTest {
     }
 
     @Test
+    void testGetCollectionProperties() {
+        def yamlCollection = "{\n" +
+                "  \"collection\": [\n" +
+                "    {\"name\": \"Item 1\"}, {\"name\": \"Item 2\"}, {\"name\": \"Item 3\"}\n" +
+                "  ]\n" +
+                "}"
+        def properties = new YAMLPropertiesSource(new TestStringResource(yamlCollection)).properties
+
+        assertEquals properties.get("collection"), "{name=Item 1},{name=Item 2},{name=Item 3}"
+    }
+
+    @Test
     void testInvalidProperties() {
         try {
             new JSONPropertiesSource(new BadResource()).properties

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/config/YAMLPropertiesSourceTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/config/YAMLPropertiesSourceTest.groovy
@@ -44,6 +44,36 @@ class YAMLPropertiesSourceTest {
     }
 
     @Test
+    void testGetFieldOrderWithRawStrings() {
+        def yamlCollection = "fieldOrder:\n" +
+                "  - username\n" +
+                "  - givenName\n" +
+                "  - middleName\n" +
+                "  - surname\n" +
+                "  - email\n" +
+                "  - password\n" +
+                "  - confirmPassword"
+        def properties = new YAMLPropertiesSource(new TestStringResource(yamlCollection)).properties
+
+        assertEquals properties.get("fieldOrder"), "username,givenName,middleName,surname,email,password,confirmPassword"
+    }
+    
+    @Test
+    void testGetFieldOrderWithQuotedStrings() {
+        def yamlCollection = "fieldOrder:\n" +
+                "  - \"username\"\n" +
+                "  - \"givenName\"\n" +
+                "  - \"middleName\"\n" +
+                "  - \"surname\"\n" +
+                "  - \"email\"\n" +
+                "  - \"password\"\n" +
+                "  - \"confirmPassword\""
+        def properties = new YAMLPropertiesSource(new TestStringResource(yamlCollection)).properties
+
+        assertEquals properties.get("fieldOrder"), "username,givenName,middleName,surname,email,password,confirmPassword"
+    }
+
+    @Test
     void testInvalidProperties() {
         try {
             new YAMLPropertiesSource(new BadResource()).properties

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/config/YAMLPropertiesSourceTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/config/YAMLPropertiesSourceTest.groovy
@@ -40,8 +40,7 @@ class YAMLPropertiesSourceTest {
                 "    - Item 4"
         def properties = new YAMLPropertiesSource(new TestStringResource(yamlCollection)).properties
 
-        assertEquals properties.get("a_sequence[0]"), "Item 1"
-        assertEquals properties.get("a_sequence[2]"), "0.5"
+        assertEquals properties.get("a_sequence"), "Item 1,Item 2,0.5,Item 4"
     }
 
     @Test


### PR DESCRIPTION
Change YAML processing to create a single comma-delimited property rather than several index-based properties.

Fixes #650.