### PR TITLE
Validate custom field values on login

### DIFF
--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/LoginController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/LoginController.java
@@ -120,7 +120,9 @@ public class LoginController extends FormController {
         String password = form.getFieldValue("password");
 
         req.login(usernameOrEmail, password);
+
         Account account = AccountResolver.INSTANCE.getRequiredAccount(req);
+
         if (account != null) {
             CustomData customData = account.getCustomData();
             // validate values in login form match values in custom data
@@ -128,9 +130,8 @@ public class LoginController extends FormController {
             for (String fieldName : fields.keySet()) {
                 if (!form.getFieldValue(fieldName).equals(customData.get(fieldName))) {
                     Field field = form.getField(fieldName);
-                    String msg = "The value for \"" + i18n(req, field.getLabel(), field.getLabel()) + "\" does not " +
-                            "match the value you previously entered. Please try again.";
-                    // question: does this need to publish an event like StormpathHttpRequest does with FailedAuthenticationRequestEvent?
+                    String fieldLabel = i18n(req, field.getLabel(), field.getLabel());
+                    String msg = i18n(req, "stormpath.web.login.form.customData.validation", new Object[]{fieldLabel});
                     throw new ValidationException(msg);
                 }
             }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/LoginController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/LoginController.java
@@ -122,18 +122,16 @@ public class LoginController extends FormController {
         req.login(usernameOrEmail, password);
         Account account = AccountResolver.INSTANCE.getRequiredAccount(req);
         if (account != null) {
-            CustomData data = account.getCustomData();
-            System.out.println("Custom data: " + data);
+            CustomData customData = account.getCustomData();
             // validate values in login form match values in custom data
-            Map<String, Object> fields = fieldValueResolver.getAllFields(req);
+            Map<String, Object> fields = getCustomData(req, form);
             for (String fieldName : fields.keySet()) {
-                if (form.getField(fieldName) != null && "customData".equals(fieldName)) {
-                    if (!form.getFieldValue(fieldName).equals(data.get(fieldName))) {
-                        Field field = form.getField(fieldName);
-                        String msg = "The value for \"" + field.getLabel() + "\" does not match the value you previously entered. Please try again";
-                        // question: does this need to publish an event like StormpathHttpRequest does with FailedAuthenticationRequestEvent?
-                        throw new ValidationException(msg);
-                    }
+                if (!form.getFieldValue(fieldName).equals(customData.get(fieldName))) {
+                    Field field = form.getField(fieldName);
+                    String msg = "The value for \"" + i18n(req, field.getLabel(), field.getLabel()) + "\" does not " +
+                            "match the value you previously entered. Please try again.";
+                    // question: does this need to publish an event like StormpathHttpRequest does with FailedAuthenticationRequestEvent?
+                    throw new ValidationException(msg);
                 }
             }
         }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/RegisterController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/RegisterController.java
@@ -20,7 +20,6 @@ import com.stormpath.sdk.account.AccountStatus;
 import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.authc.AuthenticationResult;
 import com.stormpath.sdk.client.Client;
-import com.stormpath.sdk.impl.account.DefaultAccount;
 import com.stormpath.sdk.lang.Assert;
 import com.stormpath.sdk.servlet.account.event.impl.DefaultRegisteredAccountRequestEvent;
 import com.stormpath.sdk.servlet.authc.impl.TransientAuthenticationResult;
@@ -37,7 +36,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -185,25 +183,5 @@ public class RegisterController extends FormController {
             return new DefaultViewModel(loginUri + "?status=unverified").setRedirect(true);
         }
         return new DefaultViewModel(nextUri).setRedirect(true);
-    }
-
-    private Map<String, Object> getCustomData(HttpServletRequest request, Form form) {
-        //Custom fields are either declared as form fields which shouldn't not be account fields or through a customField attribute
-        Map<String, Object> result = new LinkedHashMap<String, Object>();
-
-        for (Field field : form.getFields()) {
-            //Field is not part of the default account properties then is a custom field
-            if (DefaultAccount.PROPERTY_DESCRIPTORS.get(field.getName()) == null && !field.getName().equals(csrfTokenManager.getTokenName())) {
-                result.put(field.getName(), field.getValue());
-            }
-        }
-
-        Object customData = fieldValueResolver.getAllFields(request).get("customData");
-        if (customData instanceof Map) {
-            //noinspection unchecked
-            result.putAll((Map<? extends String, ?>) customData);
-        } //If not a map ignore, the spec doesn't cover this case
-
-        return result;
     }
 }

--- a/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/i18n.properties
+++ b/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/i18n.properties
@@ -44,6 +44,7 @@ stormpath.web.login.form.status.verified = Your Account Has Been Verified. You m
 stormpath.web.login.form.status.created = Your Account Has Been Created. You may now login.
 stormpath.web.login.form.status.forgot = Password Reset Requested. If an account exists for the email provided, you will receive an email shortly.
 stormpath.web.login.form.status.reset = Password Reset Successfully. You can now login with your new password.
+stormpath.web.login.form.customData.validation = The value for "{0}" does not match the value you previously entered. Please try again.
 
 # ==================================================
 # Register Page


### PR DESCRIPTION
Fixes #668.

To UAT, I created `examples/servlet/src/main/resources/stormpath.properties` and started Tomcat using `mvn tomcat7:run`. Here's what I put in the properties file:

```
stormpath.web.login.form.fields.favoriteColor.type = text
stormpath.web.login.form.fields.favoriteColor.label = Favorite Color
stormpath.web.login.form.fields.favoriteColor.enabled = true
stormpath.web.login.form.fields.favoriteColor.visible = true
stormpath.web.login.form.fields.favoriteColor.required = true
stormpath.web.login.form.fields.favoriteColor.placeholder = What's your favorite color?

stormpath.web.register.form.fields.favoriteColor.type = text
stormpath.web.register.form.fields.favoriteColor.label = Favorite Color
stormpath.web.register.form.fields.favoriteColor.enabled = true
stormpath.web.register.form.fields.favoriteColor.visible = true
stormpath.web.register.form.fields.favoriteColor.required = true
stormpath.web.register.form.fields.favoriteColor.placeholder = What's your favorite color?
```

I registered with a favorite color of "red". Then I tried logging in with a value of "blue" and confirmed a validation error was displayed. I then entered "red" and verified I was able to login successfully.

<img width="694" alt="screen shot 2016-06-03 at 12 15 48 pm" src="https://cloud.githubusercontent.com/assets/17892/15788596/85571e14-2985-11e6-8a90-86fce402d741.png">
