### PR TITLE
Allow configuration to disable endpoints in DefaultFilterChainResolverFactory

### DIFF
--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/Config.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/Config.java
@@ -78,4 +78,19 @@ public interface Config extends Map<String, String> {
      * @since 1.0.0
      */
     String getProducesMediaTypes();
+
+    /**
+     * @since 1.0.0
+     */
+    boolean isOAuthEnabled();
+
+    /**
+     * @since 1.0.0
+     */
+    boolean isIdSiteEnabled();
+
+    /**
+     * @since 1.0.0
+     */
+    boolean isSamlEnabled();
 }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/DefaultFilterChainResolverFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/DefaultFilterChainResolverFactory.java
@@ -96,26 +96,32 @@ public class DefaultFilterChainResolverFactory implements Factory<FilterChainRes
         String loginUrl = config.getLoginControllerConfig().getUri();
         String loginUrlPattern = cleanUri(loginUrl);
         boolean loginChainSpecified = false;
+        boolean loginEnabled = config.getLoginControllerConfig().isEnabled();
 
         String logoutUrl = config.getLogoutControllerConfig().getUri();
         String logoutUrlPattern = cleanUri(logoutUrl);
         boolean logoutChainSpecified = false;
+        boolean logoutEnabled = config.getLogoutControllerConfig().isEnabled();
 
         String forgotUrl = config.getForgotPasswordControllerConfig().getUri();
         String forgotUrlPattern = cleanUri(forgotUrl);
         boolean forgotChainSpecified = false;
+        boolean forgotPasswordEnabled = config.getForgotPasswordControllerConfig().isEnabled();
 
         String changeUrl = config.getChangePasswordControllerConfig().getUri();
         String changeUrlPattern = cleanUri(changeUrl);
         boolean changeChainSpecified = false;
+        boolean changePasswordEnabled = config.getChangePasswordControllerConfig().isEnabled();
 
         String registerUrl = config.getRegisterControllerConfig().getUri();
         String registerUrlPattern = cleanUri(registerUrl);
         boolean registerChainSpecified = false;
+        boolean registerEnabled = config.getRegisterControllerConfig().isEnabled();
 
         String verifyUrl = config.getVerifyControllerConfig().getUri();
         String verifyUrlPattern = cleanUri(verifyUrl);
         boolean verifyChainSpecified = false;
+        boolean verifyEmailEnabled = config.getVerifyControllerConfig().isEnabled();
 
         String sendVerificationUrl = config.getSendVerificationEmailControllerConfig().getUri();
         String sendVerificationUrlPattern = cleanUri(sendVerificationUrl);
@@ -124,6 +130,7 @@ public class DefaultFilterChainResolverFactory implements Factory<FilterChainRes
         String accessTokenUrl = config.getAccessTokenUrl();
         String accessTokenUrlPattern = cleanUri(accessTokenUrl);
         boolean accessTokenChainSpecified = false;
+        boolean oauthEnabled = config.isOAuthEnabled();
 
         String unauthorizedUrl = config.getUnauthorizedUrl();
         String unauthorizedUrlPattern = cleanUri(unauthorizedUrl);
@@ -132,6 +139,11 @@ public class DefaultFilterChainResolverFactory implements Factory<FilterChainRes
         String meUrl = config.getMeUrl();
         String meUrlPattern = cleanUri(meUrl);
         boolean meChainSpecified = false;
+        boolean meEnabled = config.isMeEnabled();
+
+        // todo: figure out where idsite is added to the filter chain and allow disabling
+        boolean isIdSiteEnabled = config.isIdSiteEnabled();
+        boolean isSamlEnabled = config.isSamlEnabled();
 
         String googleCallbackUrl = config.get("stormpath.web.social.google.uri");
         String googleCallbackUrlPattern = cleanUri(googleCallbackUrl);
@@ -278,31 +290,31 @@ public class DefaultFilterChainResolverFactory implements Factory<FilterChainRes
         if (!unauthorizedChainSpecified) {
             fcManager.createChain(unauthorizedUrlPattern, DefaultFilter.unauthorized.name());
         }
-        if (!loginChainSpecified) {
+        if (!loginChainSpecified && loginEnabled) {
             fcManager.createChain(loginUrlPattern, DefaultFilter.login.name());
         }
-        if (!logoutChainSpecified) {
+        if (!logoutChainSpecified && logoutEnabled) {
             fcManager.createChain(logoutUrlPattern, DefaultFilter.logout.name());
         }
-        if (!forgotChainSpecified) {
+        if (!forgotChainSpecified && forgotPasswordEnabled) {
             fcManager.createChain(forgotUrlPattern, DefaultFilter.forgot.name());
         }
-        if (!changeChainSpecified) {
+        if (!changeChainSpecified && changePasswordEnabled) {
             fcManager.createChain(changeUrlPattern, DefaultFilter.change.name());
         }
-        if (!registerChainSpecified) {
+        if (!registerChainSpecified && registerEnabled) {
             fcManager.createChain(registerUrlPattern, DefaultFilter.register.name());
         }
         if (!verifyChainSpecified) {
             fcManager.createChain(verifyUrlPattern, DefaultFilter.verify.name());
         }
-        if (!sendVerificationEmailChainSpecified) {
+        if (!sendVerificationEmailChainSpecified && verifyEmailEnabled) {
             fcManager.createChain(sendVerificationUrlPattern, DefaultFilter.sendVerificationEmail.name());
         }
-        if (!accessTokenChainSpecified) {
+        if (!accessTokenChainSpecified && oauthEnabled) {
             fcManager.createChain(accessTokenUrlPattern, DefaultFilter.accessToken.name());
         }
-        if (!meChainSpecified) {
+        if (!meChainSpecified && meEnabled) {
             fcManager.createChain(meUrlPattern, "authc," + DefaultFilter.me.name());
         }
         if (!googleCallbackChainSpecified) {

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfig.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfig.java
@@ -55,6 +55,10 @@ public class DefaultConfig implements Config {
     public static final String ME_ENABLED = "stormpath.web.me.enabled";
     public static final String ME_URL = "stormpath.web.me.uri";
 
+    public static final String OAUTH_ENABLED = "stormpath.web.oauth2.enabled";
+    public static final String ID_SITE_ENABLED = "stormpath.web.idSite.enabled";
+    public static final String CALLBACK_ENABLED = "stormpath.web.callback.enabled";
+
     private final ServletContext servletContext;
     private final ConfigReader CFG;
     private final Map<String, String> props;
@@ -70,7 +74,7 @@ public class DefaultConfig implements Config {
         this.servletContext = servletContext;
         this.props = Collections.unmodifiableMap(configProps);
         this.CFG = new ExpressionConfigReader(servletContext, this.props);
-        this.SINGLETONS = new LinkedHashMap<String, Object>();
+        this.SINGLETONS = new LinkedHashMap<>();
 
         this.ACCESS_TOKEN_COOKIE_CONFIG = new AccessTokenCookieConfig(CFG);
         this.REFRESH_TOKEN_COOKIE_CONFIG = new RefreshTokenCookieConfig(CFG);
@@ -261,6 +265,21 @@ public class DefaultConfig implements Config {
     public String getProducesMediaTypes() {
         List<String> mediaTypes = CFG.getList(PRODUCES_MEDIA_TYPES);
         return Strings.collectionToCommaDelimitedString(mediaTypes);
+    }
+
+    @Override
+    public boolean isOAuthEnabled() {
+        return CFG.getBoolean(OAUTH_ENABLED);
+    }
+
+    @Override
+    public boolean isIdSiteEnabled() {
+        return CFG.getBoolean(ID_SITE_ENABLED);
+    }
+
+    @Override
+    public boolean isSamlEnabled() {
+        return CFG.getBoolean(CALLBACK_ENABLED);
     }
 
     @SuppressWarnings("unchecked")

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/SendVerificationEmailController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/SendVerificationEmailController.java
@@ -49,11 +49,11 @@ public class SendVerificationEmailController extends FormController {
         super();
     }
 
-    public SendVerificationEmailController(Config confing) {
-        super(confing.getSendVerificationEmailControllerConfig(), confing.getProducesMediaTypes());
+    public SendVerificationEmailController(Config config) {
+        super(config.getSendVerificationEmailControllerConfig(), config.getProducesMediaTypes());
 
-        this.loginUri = confing.getLoginControllerConfig().getUri();
-        this.accountStoreResolver = confing.getAccountStoreResolver();
+        this.loginUri = config.getLoginControllerConfig().getUri();
+        this.accountStoreResolver = config.getAccountStoreResolver();
 
         Assert.hasText(this.loginUri, "loginUri cannot be null.");
         Assert.notNull(this.accountStoreResolver, "accountStoreResolver cannot be null.");

--- a/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/config/web.stormpath.properties
+++ b/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/config/web.stormpath.properties
@@ -165,7 +165,7 @@ stormpath.web.logout.invalidateHttpSession = true
 # This shows the view where a user can enter their email address to have a verification email re-sent to them.
 stormpath.web.sendVerificationEmail.uri = /sendVerificationEmail
 
-stormpath.web.sendVerificationEmail.view = stormpath/sendVerificationEmail
+stormpath.web.sendVerificationEmail.view = /sendVerificationEmail
 # The context-relative path where an authenticated (already logged in) user will be redirected when attempting to
 # access a url they are not allowed to access.
 stormpath.web.unauthorized.uri = /unauthorized

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
@@ -71,15 +71,7 @@ class SpecConfigVersusWebPropertiesTest {
 
         assertEquals diff.size(), 0, "Missing keys in default config: ${diff}"
     }
-
-    @Test
-    void listEnabledProperties() {
-        defaultProperties.each {
-            if (it.toString().contains('enabled')) {
-                println it
-            }
-        }
-    }
+    
     @Test
     void verifyPropertiesInDefaultAreInSpec() {
         def diff = defaultProperties.findResults { k,v ->

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
@@ -71,7 +71,7 @@ class SpecConfigVersusWebPropertiesTest {
 
         assertEquals diff.size(), 0, "Missing keys in default config: ${diff}"
     }
-    
+
     @Test
     void verifyPropertiesInDefaultAreInSpec() {
         def diff = defaultProperties.findResults { k,v ->

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
@@ -73,6 +73,14 @@ class SpecConfigVersusWebPropertiesTest {
     }
 
     @Test
+    void listEnabledProperties() {
+        defaultProperties.each {
+            if (it.toString().contains('enabled')) {
+                println it
+            }
+        }
+    }
+    @Test
     void verifyPropertiesInDefaultAreInSpec() {
         def diff = defaultProperties.findResults { k,v ->
             specProperties.containsKey(k) ? null : k

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
@@ -25,9 +25,7 @@ import org.yaml.snakeyaml.Yaml
 
 import java.lang.reflect.Field
 
-import static org.testng.Assert.assertEquals
-import static org.testng.Assert.assertNotNull
-
+import static org.testng.Assert.*
 /**
  * @since 1.0.RC9
  */
@@ -76,6 +74,62 @@ class DefaultConfigFactoryTest {
     @Test
     public void assertYAMLDependencyIsPresent() {
         assertNotNull(Classes.forName(Yaml.class.getName()))
+    }
+
+    @Test
+    public void verifyAllEndpointsCanBeDisabled() {
+        /* This test verifies the following properties are read properly from stormpath.properties
+            stormpath.web.oauth2.enabled=true
+            stormpath.web.register.enabled=true
+            stormpath.web.verifyEmail.enabled=true
+            stormpath.web.login.enabled=true
+            stormpath.web.logout.enabled=true
+            stormpath.web.forgotPassword.enabled=null
+            stormpath.web.changePassword.enabled=null
+            stormpath.web.idSite.enabled=false
+            stormpath.web.callback.enabled=true
+            stormpath.web.me.enabled=true
+         */
+
+        assertFalse config.isOAuthEnabled()
+        assertFalse config.getRegisterControllerConfig().isEnabled()
+        assertFalse config.getSendVerificationEmailControllerConfig().isEnabled()
+        assertFalse config.getLoginControllerConfig().isEnabled()
+        assertFalse config.getLogoutControllerConfig().isEnabled()
+        assertFalse config.getForgotPasswordControllerConfig().isEnabled()
+        assertFalse config.getChangePasswordControllerConfig().isEnabled()
+        assertFalse config.isIdSiteEnabled()
+        assertFalse config.isSamlEnabled()
+        assertFalse config.isMeEnabled()
+    }
+
+    @Test
+    public void verifyAllEndpointsCanBeEnabled() {
+        // Enable all endpoints with environment overrides since stormpath.properties has false for all
+        Map<String, String> env = new HashMap<>()
+        env.put('STORMPATH_WEB_OAUTH2_ENABLED', "true")
+        env.put('STORMPATH_WEB_REGISTER_ENABLED', "true")
+        env.put('STORMPATH_WEB_VERIFYEMAIL_ENABLED', "true")
+        env.put('STORMPATH_WEB_LOGIN_ENABLED', "true")
+        env.put('STORMPATH_WEB_LOGOUT_ENABLED', "true")
+        env.put('STORMPATH_WEB_FORGOTPASSWORD_ENABLED', "true")
+        env.put('STORMPATH_WEB_CHANGEPASSWORD_ENABLED', "true")
+        env.put('STORMPATH_WEB_IDSITE_ENABLED', "true")
+        env.put('STORMPATH_WEB_CALLBACK_ENABLED', "true")
+        env.put('STORMPATH_WEB_ME_ENABLED', "true")
+        setEnv(env)
+        config = new ConfigLoader().createConfig(new MockServletContext())
+
+        assertTrue config.isOAuthEnabled()
+        assertTrue config.getRegisterControllerConfig().isEnabled()
+        assertTrue config.getVerifyControllerConfig().isEnabled()
+        assertTrue config.getLoginControllerConfig().isEnabled()
+        assertTrue config.getLogoutControllerConfig().isEnabled()
+        assertTrue config.getForgotPasswordControllerConfig().isEnabled()
+        assertTrue config.getChangePasswordControllerConfig().isEnabled()
+        assertTrue config.isIdSiteEnabled()
+        assertTrue config.isSamlEnabled()
+        assertTrue config.isMeEnabled()
     }
 
     // From http://stackoverflow.com/a/496849

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
@@ -25,7 +25,12 @@ import org.yaml.snakeyaml.Yaml
 
 import java.lang.reflect.Field
 
-import static org.testng.Assert.*
+import static org.testng.Assert.assertEquals
+import static org.testng.Assert.assertFalse
+import static org.testng.Assert.assertTrue
+import static org.testng.Assert.assertNotNull
+
+
 /**
  * @since 1.0.RC9
  */
@@ -78,19 +83,6 @@ class DefaultConfigFactoryTest {
 
     @Test
     public void verifyAllEndpointsCanBeDisabled() {
-        /* This test verifies the following properties are read properly from stormpath.properties
-            stormpath.web.oauth2.enabled=true
-            stormpath.web.register.enabled=true
-            stormpath.web.verifyEmail.enabled=true
-            stormpath.web.login.enabled=true
-            stormpath.web.logout.enabled=true
-            stormpath.web.forgotPassword.enabled=null
-            stormpath.web.changePassword.enabled=null
-            stormpath.web.idSite.enabled=false
-            stormpath.web.callback.enabled=true
-            stormpath.web.me.enabled=true
-         */
-
         assertFalse config.isOAuthEnabled()
         assertFalse config.getRegisterControllerConfig().isEnabled()
         assertFalse config.getSendVerificationEmailControllerConfig().isEnabled()
@@ -136,8 +128,8 @@ class DefaultConfigFactoryTest {
     private static void setEnv(Map<String, String> newenv) throws Exception {
         Class[] classes = Collections.class.getDeclaredClasses();
         Map<String, String> env = System.getenv();
-        for(Class cl : classes) {
-            if('java.util.Collections$UnmodifiableMap'.equals(cl.getName())) {
+        for (Class cl : classes) {
+            if ('java.util.Collections$UnmodifiableMap'.equals(cl.getName())) {
                 Field field = cl.getDeclaredField('m');
                 field.setAccessible(true);
                 Object obj = field.get(env);

--- a/extensions/servlet/src/test/resources/stormpath.properties
+++ b/extensions/servlet/src/test/resources/stormpath.properties
@@ -1,2 +1,13 @@
 stormpath.web.login.nextUri = /foo
 stormpath.baseUrl = http://api.stormpath.com/v100
+
+stormpath.web.oauth2.enabled=false
+stormpath.web.register.enabled=false
+stormpath.web.verifyEmail.enabled=false
+stormpath.web.login.enabled=false
+stormpath.web.logout.enabled=false
+stormpath.web.forgotPassword.enabled=false
+stormpath.web.changePassword.enabled=false
+stormpath.web.idSite.enabled=false
+stormpath.web.callback.enabled=false
+stormpath.web.me.enabled=false

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
@@ -1392,6 +1392,21 @@ public abstract class AbstractStormpathWebMvcConfiguration {
             }
 
             @Override
+            public boolean isOAuthEnabled() {
+                return accessTokenEnabled;
+            }
+
+            @Override
+            public boolean isIdSiteEnabled() {
+                return idSiteEnabled;
+            }
+
+            @Override
+            public boolean isSamlEnabled() {
+                return samlEnabled;
+            }
+
+            @Override
             public int size() {
                 throw new UnsupportedOperationException("Not supported for spring environments.");
             }

--- a/impl/src/main/java/com/stormpath/sdk/impl/config/DefaultEnvVarNameConverter.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/config/DefaultEnvVarNameConverter.java
@@ -61,6 +61,18 @@ public class DefaultEnvVarNameConverter implements EnvVarNameConverter {
         if ("STORMPATH_BASEURL".equals(envVarName)) {
             return "stormpath.baseUrl";
         }
+        if ("STORMPATH_WEB_VERIFYEMAIL_ENABLED".equals((envVarName))) {
+            return "stormpath.web.verifyEmail.enabled";
+        }
+        if ("STORMPATH_WEB_FORGOTPASSWORD_ENABLED".equals((envVarName))) {
+            return "stormpath.web.forgotPassword.enabled";
+        }
+        if ("STORMPATH_WEB_CHANGEPASSWORD_ENABLED".equals((envVarName))) {
+            return "stormpath.web.changePassword.enabled";
+        }
+        if ("STORMPATH_WEB_IDSITE_ENABLED".equals((envVarName))) {
+            return "stormpath.web.idSite.enabled";
+        }
 
         //default cases:
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Fixes #712.

NOTE: I'm not sure that idSite needs to be enabled/disabled in `DefaultFilterChainResolverFactory` since it seems to be configured elsewhere.