### PR TITLE
Don't add cache-control headers for JSON Views since they're set in controllers. Also, change to be consistent with value when setting cache-control header.

### DIFF
--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/DefaultUnauthenticatedHandler.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/DefaultUnauthenticatedHandler.java
@@ -38,7 +38,7 @@ public class DefaultUnauthenticatedHandler implements UnauthenticatedHandler {
     @Override
     public boolean onAuthenticationRequired(HttpServletRequest request, HttpServletResponse response) throws Exception {
 
-        response.setHeader("Cache-Control", "no-store");
+        response.setHeader("Cache-Control", "no-store, no-cache");
         response.setHeader("Pragma", "no-cache");
 
         if (isHtmlPreferred(request)) {

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/DefaultUnauthorizedHandler.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/DefaultUnauthorizedHandler.java
@@ -18,7 +18,6 @@ package com.stormpath.sdk.servlet.filter;
 import com.stormpath.sdk.lang.Assert;
 import com.stormpath.sdk.servlet.http.UserAgent;
 import com.stormpath.sdk.servlet.http.UserAgents;
-import com.stormpath.sdk.servlet.http.impl.DefaultUserAgent;
 import com.stormpath.sdk.servlet.util.ServletUtils;
 
 import javax.servlet.ServletException;
@@ -56,7 +55,7 @@ public class DefaultUnauthorizedHandler implements UnauthorizedHandler {
             }
         } else {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-            response.setHeader("Cache-Control", "no-store");
+            response.setHeader("Cache-Control", "no-store, no-cache");
             response.setHeader("Pragma", "no-cache");
         }
 

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/http/authc/BearerAuthenticationScheme.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/http/authc/BearerAuthenticationScheme.java
@@ -107,7 +107,7 @@ public class BearerAuthenticationScheme extends AbstractAuthenticationScheme {
             // and https://github.com/stormpath/stormpath-sdk-java/issues/674
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType("application/json;charset=UTF-8");
-            response.setHeader("Cache-Control", "no-store");
+            response.setHeader("Cache-Control", "no-store, no-cache");
             response.setHeader("Pragma", "no-cache");
 
             try {

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/AccessTokenController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/AccessTokenController.java
@@ -327,7 +327,7 @@ public class AccessTokenController extends AbstractController {
         }
 
         response.setContentType("application/json;charset=UTF-8");
-        response.setHeader("Cache-Control", "no-store");
+        response.setHeader("Cache-Control", "no-store, no-cache");
         response.setHeader("Pragma", "no-cache");
         response.setHeader("Content-Length", String.valueOf(json.length()));
         response.getWriter().print(json);

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
@@ -31,8 +31,8 @@ import com.stormpath.sdk.servlet.application.ApplicationResolver;
 import com.stormpath.sdk.servlet.authz.RequestAuthorizer;
 import com.stormpath.sdk.servlet.config.Config;
 import com.stormpath.sdk.servlet.config.CookieConfig;
-import com.stormpath.sdk.servlet.config.RegisterEnabledResolver;
 import com.stormpath.sdk.servlet.config.RegisterEnabledPredicate;
+import com.stormpath.sdk.servlet.config.RegisterEnabledResolver;
 import com.stormpath.sdk.servlet.config.impl.AccessTokenCookieConfig;
 import com.stormpath.sdk.servlet.config.impl.RefreshTokenCookieConfig;
 import com.stormpath.sdk.servlet.csrf.CsrfTokenManager;
@@ -44,17 +44,17 @@ import com.stormpath.sdk.servlet.event.RequestEventListenerAdapter;
 import com.stormpath.sdk.servlet.event.TokenRevocationRequestEventListener;
 import com.stormpath.sdk.servlet.event.impl.Publisher;
 import com.stormpath.sdk.servlet.event.impl.RequestEventPublisher;
+import com.stormpath.sdk.servlet.filter.ChangePasswordConfigResolver;
 import com.stormpath.sdk.servlet.filter.ControllerConfigResolver;
+import com.stormpath.sdk.servlet.filter.DefaultServerUriResolver;
+import com.stormpath.sdk.servlet.filter.DefaultUsernamePasswordRequestFactory;
+import com.stormpath.sdk.servlet.filter.DefaultWrappedServletRequestFactory;
 import com.stormpath.sdk.servlet.filter.FilterChainResolver;
+import com.stormpath.sdk.servlet.filter.ProxiedFilterChain;
 import com.stormpath.sdk.servlet.filter.ServerUriResolver;
 import com.stormpath.sdk.servlet.filter.StormpathFilter;
 import com.stormpath.sdk.servlet.filter.UsernamePasswordRequestFactory;
 import com.stormpath.sdk.servlet.filter.WrappedServletRequestFactory;
-import com.stormpath.sdk.servlet.filter.ChangePasswordConfigResolver;
-import com.stormpath.sdk.servlet.filter.DefaultUsernamePasswordRequestFactory;
-import com.stormpath.sdk.servlet.filter.DefaultServerUriResolver;
-import com.stormpath.sdk.servlet.filter.ProxiedFilterChain;
-import com.stormpath.sdk.servlet.filter.DefaultWrappedServletRequestFactory;
 import com.stormpath.sdk.servlet.filter.account.AccountResolverFilter;
 import com.stormpath.sdk.servlet.filter.account.AuthenticationResultSaver;
 import com.stormpath.sdk.servlet.filter.account.AuthorizationHeaderAccountResolver;
@@ -597,7 +597,11 @@ public abstract class AbstractStormpathWebMvcConfiguration {
     }
 
     public org.springframework.web.servlet.View stormpathJsonView() {
-        return new MappingJackson2JsonView(objectMapper);
+        MappingJackson2JsonView jsonView = new MappingJackson2JsonView(objectMapper);
+        // 786: Suppress Jackson's setting a Cache-Control, since they're set in individual controllers
+        // Without this, we'll end up with duplicate Cache-Control headers
+        jsonView.setDisableCaching(false);
+        return jsonView;
     }
 
     interface OrderedViewResolver extends ViewResolver, Ordered {


### PR DESCRIPTION
Fixes #786.