### PR TITLE
Allow for adding / removing properties from DefaultConfig

### DIFF
--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfig.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfig.java
@@ -66,6 +66,7 @@ import javax.servlet.ServletException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -125,8 +126,8 @@ public class DefaultConfig implements Config {
         Assert.notNull(servletContext, "servletContext argument cannot be null.");
         Assert.notNull(configProps, "Properties argument cannot be null.");
         this.servletContext = servletContext;
-        this.props = Collections.unmodifiableMap(configProps);
-        this.CFG = new ExpressionConfigReader(servletContext, this.props);
+        this.props = new HashMap<>(configProps);
+        this.CFG = new ExpressionConfigReader(servletContext, Collections.unmodifiableMap(this.props));
         this.SINGLETONS = new LinkedHashMap<>();
 
         this.ACCESS_TOKEN_COOKIE_CONFIG = new AccessTokenCookieConfig(CFG);

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
@@ -28,6 +28,7 @@ import java.lang.reflect.Field
 
 import static org.testng.Assert.assertEquals
 import static org.testng.Assert.assertFalse
+import static org.testng.Assert.assertNull
 import static org.testng.Assert.assertTrue
 import static org.testng.Assert.assertNotNull
 
@@ -140,6 +141,85 @@ class DefaultConfigFactoryTest {
         env.put('STORMPATH_WEB_CALLBACK_ENABLED', 'false')
         setEnv(env)
         config = new ConfigLoader().createConfig(new MockServletContext())
+    }
+
+    /**
+     * @since 1.0.2
+     */
+    @Test
+    public void testPutPropertyUpdatesConfigMap() {
+
+        String key = "stormpath.test.value"
+        String value = "test.value.result"
+        int initialSize = config.size()
+
+        config.put(key, value)
+
+        assertEquals value, config.get(key)
+        assertEquals initialSize+1, config.size()
+    }
+
+    /**
+     * @since 1.0.2
+     */
+    @Test
+    public void testPutAllPropertiesUpdatesConfigMap() {
+
+        String key1 = "stormpath.test.value1"
+        String value1 = "test.value.result1"
+
+        String key2 = "stormpath.test.value2"
+        String value2 = "test.value.result2"
+
+        Map<String, String> additionalProperties = new HashMap<>()
+        additionalProperties.put(key1, value1)
+        additionalProperties.put(key2, value2)
+
+        int initialSize = config.size()
+
+        config.putAll(additionalProperties)
+
+        assertEquals value1, config.get(key1)
+        assertEquals value2, config.get(key2)
+        assertEquals initialSize+2, config.size()
+    }
+
+    /**
+     * @since 1.0.2
+     */
+    @Test
+    public void testRemovePropertyUpdatesConfigMap() {
+
+        String key = "stormpath.test.value"
+        String value = "test.value.result"
+        int initialSize = config.size()
+
+        // add a key (tested above)
+        config.put(key, value)
+
+        // remove the key
+        assertEquals value, config.remove(key)
+
+        assertNull config.get(key)
+        assertEquals initialSize, config.size()
+    }
+
+    /**
+     * @since 1.0.2
+     */
+    @Test
+    public void testClearPropertiesUpdatesConfigMap() {
+
+        String key = "stormpath.test.value"
+        String value = "test.value.result"
+
+        // add a key (tested above)
+        config.put(key, value)
+
+        // clear everything
+        config.clear()
+
+        assertEquals 0, config.size()
     }
 
     @AfterTest

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
@@ -144,7 +144,7 @@ class DefaultConfigFactoryTest {
     }
 
     /**
-     * @since 1.0.2
+     * @since 1.0.3
      */
     @Test
     public void testPutPropertyUpdatesConfigMap() {
@@ -160,7 +160,7 @@ class DefaultConfigFactoryTest {
     }
 
     /**
-     * @since 1.0.2
+     * @since 1.0.3
      */
     @Test
     public void testPutAllPropertiesUpdatesConfigMap() {
@@ -185,7 +185,7 @@ class DefaultConfigFactoryTest {
     }
 
     /**
-     * @since 1.0.2
+     * @since 1.0.3
      */
     @Test
     public void testRemovePropertyUpdatesConfigMap() {
@@ -205,7 +205,7 @@ class DefaultConfigFactoryTest {
     }
 
     /**
-     * @since 1.0.2
+     * @since 1.0.3
      */
     @Test
     public void testClearPropertiesUpdatesConfigMap() {


### PR DESCRIPTION
Currently `put`, `putAll`, `remove`, and `clear` cannot be used as they are backed by an unmodifiable map.

If `props` is truly not to be modified, we should instead throw an exception directly from the corresponding method (to make it more obvious)