### PR TITLE
706 spring mvc errors as json new

### DIFF
--- a/examples/spring-security-webmvc/src/main/java/com/stormpath/spring/examples/SpringSecurityWebAppConfig.java
+++ b/examples/spring-security-webmvc/src/main/java/com/stormpath/spring/examples/SpringSecurityWebAppConfig.java
@@ -36,7 +36,8 @@ import static com.stormpath.spring.config.StormpathWebSecurityConfigurer.stormpa
  * @since 1.0.RC6
  */
 @Configuration
-@ComponentScan
+// add basePackages so com.stormpath.spring.errors is scanned for ControllerAdvice-annotated classes
+@ComponentScan(basePackages = {"com.stormpath.spring"})
 @PropertySource("classpath:application.properties")
 @EnableStormpathWebSecurity
 public class SpringSecurityWebAppConfig extends WebSecurityConfigurerAdapter {

--- a/examples/spring-security-webmvc/src/main/java/com/stormpath/spring/examples/WebAppInitializer.java
+++ b/examples/spring-security-webmvc/src/main/java/com/stormpath/spring/examples/WebAppInitializer.java
@@ -41,7 +41,9 @@ public class WebAppInitializer implements WebApplicationInitializer {
         context.register(SpringSecurityWebAppConfig.class);
         sc.addListener(new ContextLoaderListener(context));
 
-        ServletRegistration.Dynamic dispatcher = sc.addServlet("dispatcher", new DispatcherServlet(context));
+        DispatcherServlet dispatcherServlet = new DispatcherServlet(context);
+        dispatcherServlet.setThrowExceptionIfNoHandlerFound(true);
+        ServletRegistration.Dynamic dispatcher = sc.addServlet("dispatcher", dispatcherServlet);
         dispatcher.setLoadOnStartup(1);
         dispatcher.addMapping("/");
 

--- a/examples/spring-webmvc/src/main/java/com/stormpath/spring/examples/WebAppConfig.java
+++ b/examples/spring-webmvc/src/main/java/com/stormpath/spring/examples/WebAppConfig.java
@@ -31,7 +31,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @EnableWebMvc
 @EnableStormpath //Stormpath base beans
 @EnableStormpathWebMvc //Stormpath web mvc beans plus out-of-the-box views
-@ComponentScan
+@ComponentScan(basePackages = {"com.stormpath.spring"}) // add basePackages so com.stormpath.spring.errors is scanned for ControllerAdvice-annotated classes
 @PropertySource("classpath:application.properties")
 public class WebAppConfig {
 

--- a/examples/spring-webmvc/src/main/java/com/stormpath/spring/examples/WebAppInitializer.java
+++ b/examples/spring-webmvc/src/main/java/com/stormpath/spring/examples/WebAppInitializer.java
@@ -37,7 +37,9 @@ public class WebAppInitializer implements WebApplicationInitializer {
         context.register(WebAppConfig.class);
         sc.addListener(new ContextLoaderListener(context));
 
-        ServletRegistration.Dynamic dispatcher = sc.addServlet("dispatcher", new DispatcherServlet(context));
+        DispatcherServlet dispatcherServlet = new DispatcherServlet(context);
+        dispatcherServlet.setThrowExceptionIfNoHandlerFound(true);
+        ServletRegistration.Dynamic dispatcher = sc.addServlet("dispatcher", dispatcherServlet);
         dispatcher.setLoadOnStartup(1);
         dispatcher.addMapping("/");
 

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/FilterChainManagerFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/FilterChainManagerFactory.java
@@ -61,7 +61,7 @@ public class FilterChainManagerFactory extends ConfigSingletonFactory<FilterChai
                     continue;
                 }
 
-                String className = config.getInstance(key);
+                String className = config.get(key);
                 Object instance = Classes.newInstance(className);
                 mgr.addFilter(instanceName, instance);
             }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/MeFilterFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/MeFilterFactory.java
@@ -36,6 +36,7 @@ public class MeFilterFactory extends FilterFactory<MeFilter> {
         c.setExpands(config.getMeExpandedProperties());
         c.setObjectMapper(config.getObjectMapper());
         c.setLoginPageRedirector(new DefaultLoginPageRedirector(config.getLoginConfig().getUri()));
+        c.setApplicationResolver(config.getApplicationResolver());
         c.init();
 
         MeFilter filter = new MeFilter();

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/MeFilter.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/MeFilter.java
@@ -16,6 +16,7 @@
 package com.stormpath.sdk.servlet.filter;
 
 import com.stormpath.sdk.servlet.filter.mvc.ControllerFilter;
+import com.stormpath.sdk.servlet.http.MediaType;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
@@ -45,7 +46,7 @@ public class MeFilter extends ControllerFilter {
         @Override
         public String getHeader(String headerName) {
             if ("Accept".equals(headerName)) {
-                return "application/json";
+                return MediaType.APPLICATION_JSON_VALUE;
             }
             return super.getHeader(headerName);
         }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/http/authc/BearerAuthenticationScheme.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/http/authc/BearerAuthenticationScheme.java
@@ -35,6 +35,7 @@ import com.stormpath.sdk.servlet.authc.impl.TransientAuthenticationResult;
 import com.stormpath.sdk.servlet.filter.account.JwtSigningKeyResolver;
 import com.stormpath.sdk.servlet.filter.oauth.OAuthErrorCode;
 import com.stormpath.sdk.servlet.filter.oauth.OAuthException;
+import com.stormpath.sdk.servlet.http.MediaType;
 import com.stormpath.sdk.servlet.http.impl.StormpathHttpServletRequest;
 import com.stormpath.sdk.servlet.oauth.AccessTokenValidationStrategy;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -106,7 +107,7 @@ public class BearerAuthenticationScheme extends AbstractAuthenticationScheme {
             //updated from SC_BAD_REQUEST to SC_UNAUTHORIZED per https://github.com/stormpath/stormpath-sdk-java/issues/681
             // and https://github.com/stormpath/stormpath-sdk-java/issues/674
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json;charset=UTF-8");
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setHeader("Cache-Control", "no-store, no-cache");
             response.setHeader("Pragma", "no-cache");
 

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/AccessTokenController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/AccessTokenController.java
@@ -43,6 +43,7 @@ import com.stormpath.sdk.servlet.filter.oauth.OAuthErrorCode;
 import com.stormpath.sdk.servlet.filter.oauth.OAuthException;
 import com.stormpath.sdk.servlet.filter.oauth.RefreshTokenAuthenticationRequestFactory;
 import com.stormpath.sdk.servlet.filter.oauth.RefreshTokenResultFactory;
+import com.stormpath.sdk.servlet.http.MediaType;
 import com.stormpath.sdk.servlet.http.Saver;
 import com.stormpath.sdk.servlet.http.authc.AuthorizationHeaderParser;
 import com.stormpath.sdk.servlet.http.authc.DefaultAuthorizationHeaderParser;
@@ -326,7 +327,7 @@ public class AccessTokenController extends AbstractController {
             }
         }
 
-        response.setContentType("application/json;charset=UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setHeader("Cache-Control", "no-store, no-cache");
         response.setHeader("Pragma", "no-cache");
         response.setHeader("Content-Length", String.valueOf(json.length()));

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/MeController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/MeController.java
@@ -21,6 +21,7 @@ import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.lang.Assert;
 import com.stormpath.sdk.servlet.account.AccountResolver;
 import com.stormpath.sdk.servlet.filter.LoginPageRedirector;
+import com.stormpath.sdk.servlet.http.MediaType;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -96,7 +97,7 @@ public class MeController extends AbstractController {
 
         response.setHeader("Cache-Control", "no-store, no-cache");
         response.setHeader("Pragma", "no-cache");
-        response.setHeader("Content-Type", "application/json");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
         //Since we don't have a restrict authentication mechanism for spring-webmvc we check if the account is there and redirect to login as per spec
         if (account == null) {

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/MeController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/MeController.java
@@ -17,6 +17,7 @@ package com.stormpath.sdk.servlet.mvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stormpath.sdk.account.Account;
+import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.lang.Assert;
 import com.stormpath.sdk.servlet.account.AccountResolver;
 import com.stormpath.sdk.servlet.filter.LoginPageRedirector;
@@ -45,6 +46,7 @@ public class MeController extends AbstractController {
         Assert.notNull(this.accountModelFactory, "accountModelFactory cannot be null.");
         Assert.notNull(this.objectMapper, "objectMapper cannot be null.");
         Assert.notEmpty(this.produces, "produces cannot be null or empty");
+        Assert.notNull(this.applicationResolver, "applicationResolver cannot be null.");
     }
 
     public LoginPageRedirector getLoginPageRedirector() {
@@ -102,6 +104,9 @@ public class MeController extends AbstractController {
                 loginPageRedirector.redirectToLoginPage(request, response);
             }
             if (isJsonPreferred(request, response)) {
+                Application application = applicationResolver.getApplication(request.getServletContext());
+                String bearerRealm = String.format("Bearer realm=\"%s\"", application.getName());
+                response.addHeader("WWW-Authenticate", bearerRealm);
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             }
             return null;

--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebSecurityConfiguration.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebSecurityConfiguration.java
@@ -15,6 +15,7 @@
  */
 package com.stormpath.spring.config;
 
+import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.authc.AuthenticationResult;
 import com.stormpath.sdk.client.Client;
 import com.stormpath.sdk.idsite.IdSiteResultListener;
@@ -52,6 +53,9 @@ public abstract class AbstractStormpathWebSecurityConfiguration {
 
     @Autowired
     protected Client client;
+
+    @Autowired
+    protected Application application;
 
     @Autowired
     @Qualifier("stormpathAuthenticationProvider")
@@ -150,6 +154,6 @@ public abstract class AbstractStormpathWebSecurityConfiguration {
     }
 
     public AuthenticationEntryPoint stormpathAuthenticationEntryPoint() {
-        return new StormpathAuthenticationEntryPoint(loginUri, produces, meUri);
+        return new StormpathAuthenticationEntryPoint(loginUri, produces, meUri, application.getName());
     }
 }

--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathAuthenticationEntryPoint.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathAuthenticationEntryPoint.java
@@ -16,7 +16,6 @@
 package com.stormpath.spring.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.lang.Assert;
 import com.stormpath.sdk.servlet.filter.ContentNegotiationResolver;
 import com.stormpath.sdk.servlet.filter.DefaultLoginPageRedirector;
@@ -77,6 +76,7 @@ public class StormpathAuthenticationEntryPoint implements AuthenticationEntryPoi
         String bearerRealm = String.format("Bearer realm=\"%s\"", applicationName);
         response.addHeader("WWW-Authenticate", bearerRealm);
         if (isJsonPreferred(request, response)) {
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             om.writeValue(response.getOutputStream(),
                new Error(ErrorConstants.ERR_ACCESS_DENIED, authException.getMessage()));
         } else {

--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebSecurityConfigurer.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebSecurityConfigurer.java
@@ -366,7 +366,6 @@ public class StormpathWebSecurityConfigurer extends SecurityConfigurerAdapter<De
                     }
                 });
             }
-
         }
     }
 

--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/errors/SpringSecurityExceptionTranslator.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/errors/SpringSecurityExceptionTranslator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stormpath.spring.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Controller advice to translate the server side exceptions to client-friendly json structures.
+ *
+ * @since 1.0.0
+ */
+@ControllerAdvice
+public class SpringSecurityExceptionTranslator extends ExceptionTranslator {
+
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ResponseBody
+    public Error processAccessDeniedException(AccessDeniedException e) {
+        return new Error(ErrorConstants.ERR_ACCESS_DENIED, e.getMessage());
+    }
+}

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
@@ -1280,6 +1280,7 @@ public abstract class AbstractStormpathWebMvcConfiguration {
         controller.setProduces(stormpathProducedMediaTypes());
         controller.setUri(meUri);
         controller.setLoginPageRedirector(new DefaultLoginPageRedirector(stormpathLoginConfig().getUri()));
+        controller.setApplicationResolver(stormpathApplicationResolver());
 
         init(controller);
 

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/CustomParameterizedException.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/CustomParameterizedException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stormpath.spring.errors;
+
+/**
+ * Custom, parameterized exception, which can be translated on the client side.
+ * For example:
+ *
+ * <pre>
+ * throw new CustomParameterizedException(&quot;myCustomError&quot;, &quot;hello&quot;, &quot;world&quot;);
+ * </pre>
+ *
+ * Can be translated with:
+ *
+ * <pre>
+ * "error.myCustomError" :  "The server says {{params[0]}} to {{params[1]}}"
+ * </pre>
+ *
+ * Copied with much respect from JHipster: https://github.com/jhipster/generator-jhipster/tree/master/generators/server/templates/src/main/java/package/web/rest/errors
+ *
+ * @since 1.0.0
+ */
+public class CustomParameterizedException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String message;
+    private final String[] params;
+
+    public CustomParameterizedException(String message, String... params) {
+        super(message);
+        this.message = message;
+        this.params = params;
+    }
+
+    public ParameterizedError getErrorDTO() {
+        return new ParameterizedError(message, params);
+    }
+
+}

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/Error.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/Error.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stormpath.spring.errors;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * DTO for transfering error status with a list of field errors.
+ *
+ * Copied with much respect from JHipster: https://github.com/jhipster/generator-jhipster/tree/master/generators/server/templates/src/main/java/package/web/rest/errors
+ *
+ * @since 1.0.0
+ */
+public class Error implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String status;
+    private final String message;
+
+    private List<FieldError> fieldErrors;
+
+    public Error(String status) {
+        this(status, null);
+    }
+
+    public Error(String status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public Error(String status, String message, List<FieldError> fieldErrors) {
+        this.status = status;
+        this.message = message;
+        this.fieldErrors = fieldErrors;
+    }
+
+    public void add(String objectName, String field, String message) {
+        if (fieldErrors == null) {
+            fieldErrors = new ArrayList<>();
+        }
+        fieldErrors.add(new FieldError(objectName, field, message));
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public List<FieldError> getFieldErrors() {
+        return fieldErrors;
+    }
+}

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/ErrorConstants.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/ErrorConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stormpath.spring.errors;
+
+/**
+ * Copied with much respect from JHipster: https://github.com/jhipster/generator-jhipster/tree/master/generators/server/templates/src/main/java/package/web/rest/errors
+ *
+ * @since 1.0.0
+ */
+public final class ErrorConstants {
+
+    public static final String ERR_ACCESS_DENIED = "error.accessDenied";
+    public static final String ERR_VALIDATION = "error.validation";
+    public static final String ERR_METHOD_NOT_SUPPORTED = "error.methodNotSupported";
+    public static final String ERR_INTERNAL_SERVER_ERROR = "error.internalServerError";
+    public static final String ERR_PAGE_NOT_FOUND = "error.pageNotFound";
+
+    private ErrorConstants() {
+    }
+
+}

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/ExceptionTranslator.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/ExceptionTranslator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stormpath.spring.errors;
+
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseEntity.BodyBuilder;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.List;
+
+/**
+ * Controller advice to translate the server side exceptions to client-friendly json structures.
+ *
+ * Copied with much respect from JHipster: https://github.com/jhipster/generator-jhipster/tree/master/generators/server/templates/src/main/java/package/web/rest/errors
+ *
+ * @since 1.0.0
+ */
+@ControllerAdvice
+public class ExceptionTranslator {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public Error processValidationError(MethodArgumentNotValidException ex) {
+        BindingResult result = ex.getBindingResult();
+        List<FieldError> fieldErrors = result.getFieldErrors();
+
+        return processFieldErrors(fieldErrors);
+    }
+
+    @ExceptionHandler(CustomParameterizedException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ParameterizedError processParameterizedValidationError(CustomParameterizedException ex) {
+        return ex.getErrorDTO();
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseBody
+    public Error processPageNotFoundException(NoHandlerFoundException e) {
+        return new Error(ErrorConstants.ERR_PAGE_NOT_FOUND, e.getMessage());
+    }
+
+    private Error processFieldErrors(List<FieldError> fieldErrors) {
+        Error dto = new Error(ErrorConstants.ERR_VALIDATION);
+
+        for (FieldError fieldError : fieldErrors) {
+            dto.add(fieldError.getObjectName(), fieldError.getField(), fieldError.getCode());
+        }
+
+        return dto;
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    @ResponseBody
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    public Error processMethodNotSupportedException(HttpRequestMethodNotSupportedException exception) {
+        return new Error(ErrorConstants.ERR_METHOD_NOT_SUPPORTED, exception.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Error> processRuntimeException(Exception ex) throws Exception {
+        BodyBuilder builder;
+        Error error;
+        ResponseStatus responseStatus = AnnotationUtils.findAnnotation(ex.getClass(), ResponseStatus.class);
+        if (responseStatus != null) {
+            builder = ResponseEntity.status(responseStatus.value());
+            error = new Error("error." + responseStatus.value().value(), responseStatus.reason());
+        } else {
+            builder = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR);
+            error = new Error(ErrorConstants.ERR_INTERNAL_SERVER_ERROR, "Internal server error");
+        }
+        return builder.body(error);
+    }
+}

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/FieldError.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/FieldError.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stormpath.spring.errors;
+
+import java.io.Serializable;
+
+/**
+ * Class for capturing Spring MVC validation messages for fields.
+ *
+ * Copied with much respect from JHipster: https://github.com/jhipster/generator-jhipster/tree/master/generators/server/templates/src/main/java/package/web/rest/errors
+ *
+ * @since 1.0.0
+ */
+public class FieldError implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String objectName;
+
+    private final String field;
+
+    private final String message;
+
+    public FieldError(String dto, String field, String message) {
+        this.objectName = dto;
+        this.field = field;
+        this.message = message;
+    }
+
+    public String getObjectName() {
+        return objectName;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/ParameterizedError.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/errors/ParameterizedError.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stormpath.spring.errors;
+
+import java.io.Serializable;
+
+/**
+ * Class for sending a parameterized error message.
+ *
+ * Copied with much respect from JHipster: https://github.com/jhipster/generator-jhipster/tree/master/generators/server/templates/src/main/java/package/web/rest/errors
+ *
+ * @since 1.0.0
+ */
+public class ParameterizedError implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private final String message;
+    private final String[] params;
+
+    public ParameterizedError(String message, String... params) {
+        this.message = message;
+        this.params = params;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String[] getParams() {
+        return params;
+    }
+
+}


### PR DESCRIPTION
Fixes #706 

**NOTE**: This replaces (and updates) the original PR: #726. There were too many merge conflicts in that, I created this one fresh off master.

# UAT:

## `Spring WebMVC Example`:

1. application/json
    1. curl -v -H "Accept: application/json" http://localhost:8080/missing
        * **returns**: 404, JSON message
    2. curl -v -H "Accept: application/json" http://localhost:8080/me
        * **returns**: 401, WWW-Authenticate header, empty body
2. text/html
    1. curl -v -H "Accept: text/html" http://localhost:8080/missing
        * **returns**: 404, HTML response
    2. curl -v -H "Accept: text/html" http://localhost:8080/me
        * **returns**: 401, WWW-Authenticate header, empty body

## `Spring Security WebMVC Example`:

1. application/json
    1. curl -v -H "Accept: application/json" http://localhost:8080/missing
        * **returns**: 401, WWW-Authenticate header, JSON message
    2. curl -v -H "Accept: application/json" http://localhost:8080/restricted
        * **returns**: 401, WWW-Authenticate header, JSON message
    3. curl -v -H "Accept: application/json" http://localhost:8080/me
        * **returns**: 401, WWW-Authenticate header, empty body
2. text/html
    1. curl -v -H "Accept: text/html" http://localhost:8080/missing
        * **returns**: 302, /login?next=%2Fmissing
    2. curl -v -H "Accept: text/html" http://localhost:8080/restricted
        * **returns**: 302, /login?next=%2Fmissing
    3. curl -v -H "Accept: text/html" http://localhost:8080/me
        * **returns**: 401, WWW-Authenticate header, empty body

## Known Issues

### Missing Content-Type

In the `Spring Security WebMVC Example` tests 1.1 and 1.2 (401 with JSON Body), the `Content-Type` header is missing.  This needs to be set for clients to interpret the payload correctly.

For example, when using httpie, the body content is not color coded because it treats it as plaintext, but when the Content-Type header is set, httpie parses it as JSON and color-codes it appropriately.  Other HTTP clients could have similar issues and/or resulting problems without the Content-Type header set.