### PR TITLE
Make i18n messages consistent for Servlet and Spring.

### DIFF
--- a/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/i18n.properties
+++ b/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/i18n.properties
@@ -105,7 +105,7 @@ stormpath.web.forgotPassword.form.status.invalid_sptoken = The password reset li
 stormpath.web.changePassword.title = Change Your Password
 stormpath.web.changePassword.form.title = Change Your Password
 stormpath.web.changePassword.form.instructions = Enter your new account password below.  Once confirmed, \
-  you'll be logged into your account and your new password will be active.
+  you''ll be logged into your account and your new password will be active.
 stormpath.web.changePassword.form.errors.strength = Password is not strong enough.  Try making it longer or adding some \
   numbers, punctuation or special characters.
 stormpath.web.changePassword.form.errors.mismatch = Password values do not match.
@@ -113,7 +113,7 @@ stormpath.web.changePassword.form.errors.invalid = Invalid password reset link. 
 
 stormpath.web.changePassword.form.errors.default = Your password reset attempt has failed.  This might happen for several \
   reasons: your reset token might be expired, it might have already been used, or we may just be having issues right \
-  now.  Please try again, and if you're still having problems, please contact the site administrator for help!
+  now.  Please try again, and if you''re still having problems, please contact the site administrator for help!
 stormpath.web.changePassword.form.errors.invalid_token = Invalid sptoken.
 stormpath.web.changePassword.form.errors.no_token = sptoken parameter not provided.
 stormpath.web.changePassword.form.fields.password.label = Password
@@ -133,14 +133,14 @@ stormpath.web.changePassword.form.loginLink.text = Back to Login
 stormpath.web.unauthorized.title = Unauthorized
 stormpath.web.unauthorized.description = You are not authorized to view the requested page.
 stormpath.web.unauthorized.description2 = If this is unexpected, please contact your site administrator for help, \
-  otherwise click your web browser's back button to return to the previous page.
+  otherwise click your web browser''s back button to return to the previous page.
 
 # ==================================================
 # Verify Email Page
 # ==================================================
 stormpath.web.verifyEmail.title = Resend Email Verification
-stormpath.web.verifyEmail.form.title = Didn't receive your account verification email?
-stormpath.web.verifyEmail.form.instructions = Enter your email address below and we'll resend your account \
+stormpath.web.verifyEmail.form.title = Didn''t receive your account verification email?
+stormpath.web.verifyEmail.form.instructions = Enter your email address below and we''ll resend your account \
   verification email. You will be sent an email which you will need to open to continue. You may need to check your \
   spam folder.
 stormpath.web.verifyEmail.form.fields.email.label = Email
@@ -170,10 +170,10 @@ stormpath.web.errors.1906 = You cannot add more than one credit card to your sub
 stormpath.web.errors.1910 = Cannot send an email with the specified mime type on the developer tier. Modify the email template or upgrade your Stormpath Tenant.
 stormpath.web.errors.1920 = The card number is incorrect.
 stormpath.web.errors.1921 = The card number is not a valid credit card number.
-stormpath.web.errors.1922 = The card's expiration month is invalid.
-stormpath.web.errors.1923 = The card's expiration year is invalid.
-stormpath.web.errors.1924 = The card's security code is invalid.
-stormpath.web.errors.1925 = The card's security code is incorrect.
+stormpath.web.errors.1922 = The card''s expiration month is invalid.
+stormpath.web.errors.1923 = The card''s expiration year is invalid.
+stormpath.web.errors.1924 = The card''s security code is invalid.
+stormpath.web.errors.1925 = The card''s security code is incorrect.
 stormpath.web.errors.1926 = The card has expired.
 stormpath.web.errors.1927 = The card was declined.
 stormpath.web.errors.1928 = An error occurred while processing the card.

--- a/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/main/java/com/stormpath/spring/boot/autoconfigure/StormpathWebMvcAutoConfiguration.java
+++ b/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/main/java/com/stormpath/spring/boot/autoconfigure/StormpathWebMvcAutoConfiguration.java
@@ -69,8 +69,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
-import org.springframework.boot.context.embedded.FilterRegistrationBean;
-import org.springframework.boot.context.embedded.ServletListenerRegistrationBean;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
@@ -79,12 +79,10 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
-import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.LocaleResolver;
-import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 
@@ -564,6 +562,8 @@ public class StormpathWebMvcAutoConfiguration extends AbstractStormpathWebMvcCon
 
             ResourceBundleMessageSource src = new ResourceBundleMessageSource();
             String[] basenames = list.toArray(new String[list.size()]);
+            // Fix for https://github.com/stormpath/stormpath-sdk-java/issues/811
+            src.setAlwaysUseMessageFormat(true);
             src.setBasenames(basenames);
             src.setDefaultEncoding("UTF-8");
             return src;
@@ -592,6 +592,8 @@ public class StormpathWebMvcAutoConfiguration extends AbstractStormpathWebMvcCon
 
             ResourceBundleMessageSource src = new ResourceBundleMessageSource();
             String[] basenames = list.toArray(new String[list.size()]);
+            // Fix for https://github.com/stormpath/stormpath-sdk-java/issues/811
+            src.setAlwaysUseMessageFormat(true);
             src.setBasenames(basenames);
             src.setDefaultEncoding("UTF-8");
             return src;
@@ -614,7 +616,7 @@ public class StormpathWebMvcAutoConfiguration extends AbstractStormpathWebMvcCon
             }
         };
 
-        return new ServletListenerRegistrationBean<ServletContextListener>(listener);
+        return new ServletListenerRegistrationBean<>(listener);
     }
 
     @Bean

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
@@ -175,7 +175,6 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.PathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -1170,6 +1169,10 @@ public abstract class AbstractStormpathWebMvcConfiguration {
 
     protected MessageSource createI18nPropertiesMessageSource() {
         ResourceBundleMessageSource src = new ResourceBundleMessageSource();
+        // Fix for https://github.com/stormpath/stormpath-sdk-java/issues/811
+        // Force same behavior as servlet i18n - all single quotes need to have double quotes.
+        // http://stackoverflow.com/a/19187306/65681
+        src.setAlwaysUseMessageFormat(true);
         src.setBasename(I18N_PROPERTIES_BASENAME);
         src.setDefaultEncoding("UTF-8");
         return src;


### PR DESCRIPTION
Make i18n messages consistent for Servlet and Spring by forcing Spring to always use `MessageFormat`, even for messages without arguments. This means that all single apostrophes should be double apostrophes in i18n.properties.

Fixes #811.

To UAT:

`mvn tomcat7:run -f examples/servlet` and go to http://localhost:8080/verify. Ensure the title and message render with aphostrophe's in them.

`mvn tomcat7:run -f examples/spring-webmvc` and go to http://localhost:8080/verify. Ensure the title and message render with aphostrophe's in them.

`mvn spring-boot:run -f examples/spring-boot-default` and go to http://localhost:8080/verify. Ensure the title and message render with aphostrophe's in them.