### PR TITLE
Add stormpath_social grant type

### DIFF
--- a/api/src/main/java/com/stormpath/sdk/oauth/Authenticators.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/Authenticators.java
@@ -35,22 +35,22 @@ import com.stormpath.sdk.lang.Classes;
  *      <td>Validation Criteria</td><td>Locally</td><td>Stormpath</td>
  *   <tr/>
  *   <tr>
- *      <td>Token hasnt been tampered with</td><td>yes</td><td>yes</td>
+ *      <td>Token hasn't been tampered with</td><td>yes</td><td>yes</td>
  *   </tr>
  *   <tr>
- *      <td>Token hasnt expired</td><td>yes</td><td>yes</td>
+ *      <td>Token hasn't expired</td><td>yes</td><td>yes</td>
  *   </tr>
  *   <tr>
- *      <td>Token hasnt been revoked</td><td>no</td><td>yes</td>
+ *      <td>Token hasn't been revoked</td><td>no</td><td>yes</td>
  *   </tr>
  *   <tr>
- *      <td>Account hasnt been disabled, and hasnt been deleted</td><td>no</td><td>yes</td>
+ *      <td>Account hasn't been disabled, and hasn't been deleted</td><td>no</td><td>yes</td>
  *   </tr>
  *   <tr>
  *      <td>Issuer is Stormpath</td><td>yes</td><td>yes</td>
  *   </tr>
  *   <tr>
- *      <td>Issuing application is still enabled, and hasnt been deleted</td><td>no</td><td>yes</td>
+ *      <td>Issuing application is still enabled, and hasn't been deleted</td><td>no</td><td>yes</td>
  *   </tr>
  *   <tr>
  *      <td>Account is still in an account store for the issuing application</td><td>no</td><td>yes</td>
@@ -120,5 +120,13 @@ public class Authenticators {
      */
     public static final OAuthClientCredentialsRequestAuthenticatorFactory OAUTH_CLIENT_CREDENTIALS_GRANT_REQUEST_AUTHENTICATOR =
             (OAuthClientCredentialsRequestAuthenticatorFactory) Classes.newInstance("com.stormpath.sdk.impl.oauth.DefaultOAuthClientCredentialsRequestAuthenticatorFactory");
+
+    /**
+     * Constructs {@link OAuthStormpathSocialGrantRequestAuthenticator}s.
+     *
+     * @since 1.1.0
+     */
+    public static final OAuthStormpathSocialRequestAuthenticatorFactory OAUTH_STORMPATH_SOCIAL_GRANT_REQUEST_AUTHENTICATOR =
+            (OAuthStormpathSocialRequestAuthenticatorFactory) Classes.newInstance("com.stormpath.sdk.impl.oauth.DefaultOAuthStormpathSocialRequestAuthenticatorFactory");
 }
 

--- a/api/src/main/java/com/stormpath/sdk/oauth/OAuthStormpathSocialGrantRequestAuthentication.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/OAuthStormpathSocialGrantRequestAuthentication.java
@@ -4,7 +4,7 @@ package com.stormpath.sdk.oauth;
  * This class represents a request for Stormpath to authenticate an Account and exchange its api key and api secret for a valid OAuth 2.0 access token.
  * Using stormpath_social grant type
  *
- * @since 1.0.0
+ * @since 1.1.0
  */
 public interface OAuthStormpathSocialGrantRequestAuthentication extends OAuthGrantRequestAuthentication {
     String getApiKeyId();

--- a/api/src/main/java/com/stormpath/sdk/oauth/OAuthStormpathSocialGrantRequestAuthentication.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/OAuthStormpathSocialGrantRequestAuthentication.java
@@ -1,0 +1,13 @@
+package com.stormpath.sdk.oauth;
+
+/**
+ * This class represents a request for Stormpath to authenticate an Account and exchange its api key and api secret for a valid OAuth 2.0 access token.
+ * Using stormpath_social grant type
+ *
+ * @since 1.0.0
+ */
+public interface OAuthStormpathSocialGrantRequestAuthentication extends OAuthGrantRequestAuthentication {
+    String getApiKeyId();
+
+    String getApiKeySecret();
+}

--- a/api/src/main/java/com/stormpath/sdk/oauth/OAuthStormpathSocialGrantRequestAuthentication.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/OAuthStormpathSocialGrantRequestAuthentication.java
@@ -1,13 +1,15 @@
 package com.stormpath.sdk.oauth;
 
 /**
- * This class represents a request for Stormpath to authenticate an Account and exchange its api key and api secret for a valid OAuth 2.0 access token.
+ * This class represents a request for Stormpath to authenticate an Account and exchange its providerId and accessToken (or code) for a valid OAuth 2.0 access token.
  * Using stormpath_social grant type
  *
  * @since 1.1.0
  */
 public interface OAuthStormpathSocialGrantRequestAuthentication extends OAuthGrantRequestAuthentication {
-    String getApiKeyId();
+    String getProviderId();
 
-    String getApiKeySecret();
+    String getAccessToken();
+
+    String getCode();
 }

--- a/api/src/main/java/com/stormpath/sdk/oauth/OAuthStormpathSocialGrantRequestAuthenticator.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/OAuthStormpathSocialGrantRequestAuthenticator.java
@@ -1,0 +1,7 @@
+package com.stormpath.sdk.oauth;
+
+/**
+ * @since 1.1.0
+ */
+public interface OAuthStormpathSocialGrantRequestAuthenticator extends OAuthRequestAuthenticator<OAuthGrantRequestAuthenticationResult> {
+}

--- a/api/src/main/java/com/stormpath/sdk/oauth/OAuthStormpathSocialRequestAuthenticatorFactory.java
+++ b/api/src/main/java/com/stormpath/sdk/oauth/OAuthStormpathSocialRequestAuthenticatorFactory.java
@@ -1,0 +1,7 @@
+package com.stormpath.sdk.oauth;
+
+/**
+ * @since 1.1.0
+ */
+public interface OAuthStormpathSocialRequestAuthenticatorFactory extends OAuthRequestAuthenticatorFactory<OAuthStormpathSocialGrantRequestAuthenticator> {
+}

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/AccessTokenController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/AccessTokenController.java
@@ -22,6 +22,7 @@ import com.stormpath.sdk.http.HttpMethod;
 import com.stormpath.sdk.impl.authc.DefaultBasicApiAuthenticationRequest;
 import com.stormpath.sdk.impl.authc.DefaultHttpServletRequestWrapper;
 import com.stormpath.sdk.impl.oauth.DefaultOAuthClientCredentialsGrantRequestAuthentication;
+import com.stormpath.sdk.impl.oauth.DefaultOAuthStormpathSocialGrantRequestAuthentication;
 import com.stormpath.sdk.lang.Assert;
 import com.stormpath.sdk.oauth.AccessTokenResult;
 import com.stormpath.sdk.oauth.Authenticators;
@@ -29,6 +30,7 @@ import com.stormpath.sdk.oauth.OAuthClientCredentialsGrantRequestAuthentication;
 import com.stormpath.sdk.oauth.OAuthGrantRequestAuthenticationResult;
 import com.stormpath.sdk.oauth.OAuthPasswordGrantRequestAuthentication;
 import com.stormpath.sdk.oauth.OAuthRefreshTokenRequestAuthentication;
+import com.stormpath.sdk.oauth.OAuthStormpathSocialGrantRequestAuthentication;
 import com.stormpath.sdk.resource.ResourceException;
 import com.stormpath.sdk.servlet.authc.FailedAuthenticationRequestEvent;
 import com.stormpath.sdk.servlet.authc.SuccessfulAuthenticationRequestEvent;
@@ -64,6 +66,7 @@ public class AccessTokenController extends AbstractController {
 
     private static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
     private static final String PASSWORD_GRANT_TYPE = "password";
+    private static final String STORMPATH_SOCIAL_GRANT_TYPE = "stormpath_social";
     private static final String REFRESH_TOKEN_GRANT_TYPE = "refresh_token";
     private static final String GRANT_TYPE_PARAM_NAME = "grant_type";
     private static final String AUTHORIZATION = "Authorization";
@@ -255,6 +258,31 @@ public class AccessTokenController extends AbstractController {
         return createAccessTokenResult(request, response, authenticationResult);
     }
 
+    /**
+     * @since 1.1.0
+     */
+    private AccessTokenResult stormpathSocialAuthenticationRequest(HttpServletRequest request, HttpServletResponse response) {
+        OAuthGrantRequestAuthenticationResult authenticationResult;
+
+        try {
+            Application app = getApplication(request);
+            String providerId = request.getParameter("providerId");
+            String accessToken = request.getParameter("accessToken");
+            String code = request.getParameter("code");
+            OAuthStormpathSocialGrantRequestAuthentication grantRequestAuthentication =
+                    new DefaultOAuthStormpathSocialGrantRequestAuthentication(providerId, accessToken, code);
+
+            authenticationResult = Authenticators.OAUTH_STORMPATH_SOCIAL_GRANT_REQUEST_AUTHENTICATOR
+                    .forApplication(app)
+                    .authenticate(grantRequestAuthentication);
+        } catch (ResourceException e) {
+            log.debug("Unable to authenticate stormpath social grant request: {}", e.getMessage(), e);
+            throw new OAuthException(OAuthErrorCode.INVALID_CLIENT, "Unable to authenticate stormpath social grant request");
+        }
+
+        return createAccessTokenResult(request, response, authenticationResult);
+    }
+
     @Override
     protected ViewModel doPost(HttpServletRequest request, HttpServletResponse response) throws Exception {
 
@@ -285,6 +313,14 @@ public class AccessTokenController extends AbstractController {
                 case CLIENT_CREDENTIALS_GRANT_TYPE:
                     try {
                         result = this.clientCredentialsAuthenticationRequest(request, response);
+                    } catch (HttpAuthenticationException e) {
+                        log.warn("Unable to authenticate client", e);
+                        throw new OAuthException(OAuthErrorCode.INVALID_CLIENT);
+                    }
+                    break;
+                case STORMPATH_SOCIAL_GRANT_TYPE:
+                    try {
+                        result = this.stormpathSocialAuthenticationRequest(request, response);
                     } catch (HttpAuthenticationException e) {
                         log.warn("Unable to authenticate client", e);
                         throw new OAuthException(OAuthErrorCode.INVALID_CLIENT);

--- a/impl/src/main/java/com/stormpath/sdk/impl/application/DefaultApplication.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/application/DefaultApplication.java
@@ -60,6 +60,7 @@ import com.stormpath.sdk.impl.oauth.DefaultOAuthBearerRequestAuthenticator;
 import com.stormpath.sdk.impl.oauth.DefaultOAuthClientCredentialsGrantRequestAuthenticator;
 import com.stormpath.sdk.impl.oauth.DefaultOAuthPasswordGrantRequestAuthenticator;
 import com.stormpath.sdk.impl.oauth.DefaultOAuthRefreshTokenRequestAuthenticator;
+import com.stormpath.sdk.impl.oauth.DefaultOAuthStormpathSocialGrantRequestAuthenticator;
 import com.stormpath.sdk.impl.provider.ProviderAccountResolver;
 import com.stormpath.sdk.impl.query.DefaultEqualsExpressionFactory;
 import com.stormpath.sdk.impl.query.Expandable;
@@ -82,6 +83,7 @@ import com.stormpath.sdk.oauth.OAuthClientCredentialsGrantRequestAuthenticator;
 import com.stormpath.sdk.oauth.OAuthPasswordGrantRequestAuthenticator;
 import com.stormpath.sdk.oauth.OAuthPolicy;
 import com.stormpath.sdk.oauth.OAuthRefreshTokenRequestAuthenticator;
+import com.stormpath.sdk.oauth.OAuthStormpathSocialGrantRequestAuthenticator;
 import com.stormpath.sdk.organization.Organization;
 import com.stormpath.sdk.organization.OrganizationCriteria;
 import com.stormpath.sdk.organization.OrganizationList;
@@ -839,6 +841,11 @@ public class DefaultApplication extends AbstractExtendableInstanceResource imple
     /* @since 1.0.0 */
     public OAuthClientCredentialsGrantRequestAuthenticator createClientCredentialsGrantAuthenticator() {
         return new DefaultOAuthClientCredentialsGrantRequestAuthenticator(this, getDataStore());
+    }
+
+    /* @since 1.1.0 */
+    public OAuthStormpathSocialGrantRequestAuthenticator createStormpathSocialGrantAuthenticator() {
+        return new DefaultOAuthStormpathSocialGrantRequestAuthenticator(this, getDataStore());
     }
 
     /* @since 1.0.RC7 */

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantAuthenticationAttempt.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantAuthenticationAttempt.java
@@ -13,10 +13,11 @@ import java.util.Map;
 public class DefaultOAuthStormpathSocialGrantAuthenticationAttempt extends AbstractResource implements OAuthStormpathSocialGrantAuthenticationAttempt {
 
     static final StringProperty GRANT_TYPE = new StringProperty("grant_type");
-    static final StringProperty API_KEY_ID = new StringProperty("apiKeyId");
-    static final StringProperty API_KEY_SECRET = new StringProperty("apiKeySecret");
+    static final StringProperty PROVIDER_ID = new StringProperty("providerId");
+    static final StringProperty ACCESS_TOKEN = new StringProperty("accessToken");
+    static final StringProperty CODE = new StringProperty("code");
 
-    private static final Map<String, Property> PROPERTY_DESCRIPTORS = createPropertyDescriptorMap(GRANT_TYPE, API_KEY_ID, API_KEY_SECRET);
+    private static final Map<String, Property> PROPERTY_DESCRIPTORS = createPropertyDescriptorMap(GRANT_TYPE, PROVIDER_ID, ACCESS_TOKEN, CODE);
 
     public DefaultOAuthStormpathSocialGrantAuthenticationAttempt(InternalDataStore dataStore) {
         super(dataStore);
@@ -32,25 +33,34 @@ public class DefaultOAuthStormpathSocialGrantAuthenticationAttempt extends Abstr
     }
 
     @Override
-    public void setApiKeyId(String apiKeyId) {
-        setProperty(API_KEY_ID, apiKeyId);
+    public void setProviderId(String providerId) {
+        setProperty(PROVIDER_ID, providerId);
     }
 
     @Override
-    public void setApiKeySecret(String apiKeySecret) {
-        setProperty(API_KEY_SECRET, apiKeySecret);
+    public void setAccessToken(String accessToken) {
+        setProperty(ACCESS_TOKEN, accessToken);
+    }
+
+    @Override
+    public void setCode(String code) {
+        setProperty(CODE, code);
     }
 
     public String getGrantType() {
         return getString(GRANT_TYPE);
     }
 
-    public String getApiKeyId() {
-        return getString(API_KEY_ID);
+    public String getProviderId() {
+        return getString(PROVIDER_ID);
     }
 
-    public String getApiKeySecret() {
-        return getString(API_KEY_SECRET);
+    public String getAccessToken() {
+        return getString(ACCESS_TOKEN);
+    }
+
+    public String getCode() {
+        return getString(CODE);
     }
 
     @Override

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantAuthenticationAttempt.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantAuthenticationAttempt.java
@@ -1,0 +1,60 @@
+package com.stormpath.sdk.impl.oauth;
+
+import com.stormpath.sdk.impl.ds.InternalDataStore;
+import com.stormpath.sdk.impl.resource.AbstractResource;
+import com.stormpath.sdk.impl.resource.Property;
+import com.stormpath.sdk.impl.resource.StringProperty;
+
+import java.util.Map;
+
+/**
+ * @since 1.1.0
+ */
+public class DefaultOAuthStormpathSocialGrantAuthenticationAttempt extends AbstractResource implements OAuthStormpathSocialGrantAuthenticationAttempt {
+
+    static final StringProperty GRANT_TYPE = new StringProperty("grant_type");
+    static final StringProperty API_KEY_ID = new StringProperty("apiKeyId");
+    static final StringProperty API_KEY_SECRET = new StringProperty("apiKeySecret");
+
+    private static final Map<String, Property> PROPERTY_DESCRIPTORS = createPropertyDescriptorMap(GRANT_TYPE, API_KEY_ID, API_KEY_SECRET);
+
+    public DefaultOAuthStormpathSocialGrantAuthenticationAttempt(InternalDataStore dataStore) {
+        super(dataStore);
+    }
+
+    public DefaultOAuthStormpathSocialGrantAuthenticationAttempt(InternalDataStore dataStore, Map<String, Object> properties) {
+        super(dataStore, properties);
+    }
+
+    @Override
+    public void setGrantType(String grantType) {
+        setProperty(GRANT_TYPE, grantType);
+    }
+
+    @Override
+    public void setApiKeyId(String apiKeyId) {
+        setProperty(API_KEY_ID, apiKeyId);
+    }
+
+    @Override
+    public void setApiKeySecret(String apiKeySecret) {
+        setProperty(API_KEY_SECRET, apiKeySecret);
+    }
+
+    public String getGrantType() {
+        return getString(GRANT_TYPE);
+    }
+
+    public String getApiKeyId() {
+        return getString(API_KEY_ID);
+    }
+
+    public String getApiKeySecret() {
+        return getString(API_KEY_SECRET);
+    }
+
+    @Override
+    public Map<String, Property> getPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+}

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantRequestAuthentication.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantRequestAuthentication.java
@@ -9,25 +9,37 @@ import com.stormpath.sdk.oauth.OAuthStormpathSocialGrantRequestAuthentication;
 public class DefaultOAuthStormpathSocialGrantRequestAuthentication implements OAuthStormpathSocialGrantRequestAuthentication {
     private final static String grant_type = "stormpath_social";
 
-    private String apiKeyId;
-    private String apiKeySecret;
+    private String providerId;
+    private String accessToken;
+    private String code;
 
-    public DefaultOAuthStormpathSocialGrantRequestAuthentication(String apiKeyId, String apiKeySecret) {
-        Assert.hasText(apiKeyId, "apiKeyId cannot be null or empty.");
-        Assert.hasText(apiKeySecret, "apiKeySecret cannot be null or empty.");
+    public DefaultOAuthStormpathSocialGrantRequestAuthentication(String providerId, String accessToken, String code) {
+        Assert.hasText(providerId, "providerId cannot be null or empty.");
+        if (code == null) {
+            Assert.hasText(accessToken, "accessToken cannot be null or empty.");
+        }
+        if (accessToken == null) {
+            Assert.hasText(code, "code cannot be null or empty.");
+        }
 
-        this.apiKeyId = apiKeyId;
-        this.apiKeySecret = apiKeySecret;
+        this.providerId = providerId;
+        this.accessToken = accessToken;
+        this.code = code;
     }
 
     @Override
-    public String getApiKeyId() {
-        return apiKeyId;
+    public String getProviderId() {
+        return providerId;
     }
 
     @Override
-    public String getApiKeySecret() {
-        return apiKeySecret;
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
     }
 
     @Override

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantRequestAuthentication.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantRequestAuthentication.java
@@ -1,0 +1,37 @@
+package com.stormpath.sdk.impl.oauth;
+
+import com.stormpath.sdk.lang.Assert;
+import com.stormpath.sdk.oauth.OAuthStormpathSocialGrantRequestAuthentication;
+
+/**
+ * @since 1.1.0
+ */
+public class DefaultOAuthStormpathSocialGrantRequestAuthentication implements OAuthStormpathSocialGrantRequestAuthentication {
+    private final static String grant_type = "stormpath_social";
+
+    private String apiKeyId;
+    private String apiKeySecret;
+
+    public DefaultOAuthStormpathSocialGrantRequestAuthentication(String apiKeyId, String apiKeySecret) {
+        Assert.hasText(apiKeyId, "apiKeyId cannot be null or empty.");
+        Assert.hasText(apiKeySecret, "apiKeySecret cannot be null or empty.");
+
+        this.apiKeyId = apiKeyId;
+        this.apiKeySecret = apiKeySecret;
+    }
+
+    @Override
+    public String getApiKeyId() {
+        return apiKeyId;
+    }
+
+    @Override
+    public String getApiKeySecret() {
+        return apiKeySecret;
+    }
+
+    @Override
+    public String getGrantType() {
+        return grant_type;
+    }
+}

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantRequestAuthenticationResultBuilder.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantRequestAuthenticationResultBuilder.java
@@ -1,0 +1,27 @@
+package com.stormpath.sdk.impl.oauth;
+
+import com.stormpath.sdk.lang.Assert;
+import com.stormpath.sdk.oauth.GrantAuthenticationToken;
+
+/**
+ * @since 1.1.0
+ */
+public class DefaultOAuthStormpathSocialGrantRequestAuthenticationResultBuilder extends DefaultOAuthGrantRequestAuthenticationResultBuilder {
+
+    public DefaultOAuthStormpathSocialGrantRequestAuthenticationResultBuilder(GrantAuthenticationToken grantAuthenticationToken) {
+        super(grantAuthenticationToken);
+    }
+
+    @Override
+    public DefaultOAuthGrantRequestAuthenticationResult build() {
+        Assert.notNull(this.grantAuthenticationToken, "grantAuthenticationToken has not been set. It is a required attribute.");
+
+        this.accessToken = grantAuthenticationToken.getAsAccessToken();
+        this.accessTokenString = grantAuthenticationToken.getAccessToken();
+        this.accessTokenHref = grantAuthenticationToken.getAccessTokenHref();
+        this.tokenType = grantAuthenticationToken.getTokenType();
+        this.expiresIn = Integer.parseInt(grantAuthenticationToken.getExpiresIn());
+
+        return new DefaultOAuthGrantRequestAuthenticationResult(this);
+    }
+}

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantRequestAuthenticator.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantRequestAuthenticator.java
@@ -26,17 +26,23 @@ public class DefaultOAuthStormpathSocialGrantRequestAuthenticator extends Abstra
     public OAuthGrantRequestAuthenticationResult authenticate(OAuthRequestAuthentication authenticationRequest) {
         Assert.notNull(this.application, "application cannot be null or empty");
         Assert.isInstanceOf(OAuthStormpathSocialGrantRequestAuthentication.class, authenticationRequest, "authenticationRequest must be an instance of OAuthStormpathSocialGrantRequestAuthentication.");
-        OAuthStormpathSocialGrantRequestAuthentication oAuthStormpathSocialGrantRequestAuthentication = (OAuthStormpathSocialGrantRequestAuthentication) authenticationRequest;
+        OAuthStormpathSocialGrantRequestAuthentication authentication = (OAuthStormpathSocialGrantRequestAuthentication) authenticationRequest;
 
-        OAuthStormpathSocialGrantAuthenticationAttempt oAuthStormpathSocialGrantAuthenticationAttempt = new DefaultOAuthStormpathSocialGrantAuthenticationAttempt(dataStore);
-        oAuthStormpathSocialGrantAuthenticationAttempt.setGrantType(oAuthStormpathSocialGrantRequestAuthentication.getGrantType());
-        oAuthStormpathSocialGrantAuthenticationAttempt.setApiKeyId(oAuthStormpathSocialGrantRequestAuthentication.getApiKeyId());
-        oAuthStormpathSocialGrantAuthenticationAttempt.setApiKeySecret(oAuthStormpathSocialGrantRequestAuthentication.getApiKeySecret());
+        OAuthStormpathSocialGrantAuthenticationAttempt authenticationAttempt = new DefaultOAuthStormpathSocialGrantAuthenticationAttempt(dataStore);
+        authenticationAttempt.setGrantType(authentication.getGrantType());
+        authenticationAttempt.setProviderId(authentication.getProviderId());
+        if (authentication.getAccessToken() != null) {
+            authenticationAttempt.setAccessToken(authentication.getAccessToken());
+        } else if (authentication.getCode() != null) {
+            authenticationAttempt.setCode(authentication.getCode());
+        } else {
+            throw new IllegalArgumentException("An accessToken or code is required for grant type 'stormpath_social'.");
+        }
 
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        GrantAuthenticationToken grantResult = dataStore.create(application.getHref() + OAUTH_TOKEN_PATH, oAuthStormpathSocialGrantAuthenticationAttempt, GrantAuthenticationToken.class, httpHeaders);
+        GrantAuthenticationToken grantResult = dataStore.create(application.getHref() + OAUTH_TOKEN_PATH, authenticationAttempt, GrantAuthenticationToken.class, httpHeaders);
 
         OAuthGrantRequestAuthenticationResultBuilder builder = new DefaultOAuthStormpathSocialGrantRequestAuthenticationResultBuilder(grantResult);
 

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantRequestAuthenticator.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialGrantRequestAuthenticator.java
@@ -1,0 +1,45 @@
+package com.stormpath.sdk.impl.oauth;
+
+import com.stormpath.sdk.application.Application;
+import com.stormpath.sdk.ds.DataStore;
+import com.stormpath.sdk.impl.http.HttpHeaders;
+import com.stormpath.sdk.impl.http.MediaType;
+import com.stormpath.sdk.lang.Assert;
+import com.stormpath.sdk.oauth.GrantAuthenticationToken;
+import com.stormpath.sdk.oauth.OAuthStormpathSocialGrantRequestAuthentication;
+import com.stormpath.sdk.oauth.OAuthGrantRequestAuthenticationResult;
+import com.stormpath.sdk.oauth.OAuthRequestAuthentication;
+import com.stormpath.sdk.oauth.OAuthStormpathSocialGrantRequestAuthenticator;
+
+/**
+ * @since 1.1.0
+ */
+public class DefaultOAuthStormpathSocialGrantRequestAuthenticator extends AbstractOAuthRequestAuthenticator implements OAuthStormpathSocialGrantRequestAuthenticator {
+
+    private final static String OAUTH_TOKEN_PATH = "/oauth/token";
+
+    public DefaultOAuthStormpathSocialGrantRequestAuthenticator(Application application, DataStore dataStore) {
+        super(application, dataStore);
+    }
+
+    @Override
+    public OAuthGrantRequestAuthenticationResult authenticate(OAuthRequestAuthentication authenticationRequest) {
+        Assert.notNull(this.application, "application cannot be null or empty");
+        Assert.isInstanceOf(OAuthStormpathSocialGrantRequestAuthentication.class, authenticationRequest, "authenticationRequest must be an instance of OAuthStormpathSocialGrantRequestAuthentication.");
+        OAuthStormpathSocialGrantRequestAuthentication oAuthStormpathSocialGrantRequestAuthentication = (OAuthStormpathSocialGrantRequestAuthentication) authenticationRequest;
+
+        OAuthStormpathSocialGrantAuthenticationAttempt oAuthStormpathSocialGrantAuthenticationAttempt = new DefaultOAuthStormpathSocialGrantAuthenticationAttempt(dataStore);
+        oAuthStormpathSocialGrantAuthenticationAttempt.setGrantType(oAuthStormpathSocialGrantRequestAuthentication.getGrantType());
+        oAuthStormpathSocialGrantAuthenticationAttempt.setApiKeyId(oAuthStormpathSocialGrantRequestAuthentication.getApiKeyId());
+        oAuthStormpathSocialGrantAuthenticationAttempt.setApiKeySecret(oAuthStormpathSocialGrantRequestAuthentication.getApiKeySecret());
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        GrantAuthenticationToken grantResult = dataStore.create(application.getHref() + OAUTH_TOKEN_PATH, oAuthStormpathSocialGrantAuthenticationAttempt, GrantAuthenticationToken.class, httpHeaders);
+
+        OAuthGrantRequestAuthenticationResultBuilder builder = new DefaultOAuthStormpathSocialGrantRequestAuthenticationResultBuilder(grantResult);
+
+        return builder.build();
+    }
+}

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialRequestAuthenticatorFactory.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/DefaultOAuthStormpathSocialRequestAuthenticatorFactory.java
@@ -1,0 +1,16 @@
+package com.stormpath.sdk.impl.oauth;
+
+import com.stormpath.sdk.application.Application;
+import com.stormpath.sdk.impl.application.DefaultApplication;
+import com.stormpath.sdk.oauth.OAuthStormpathSocialGrantRequestAuthenticator;
+import com.stormpath.sdk.oauth.OAuthStormpathSocialRequestAuthenticatorFactory;
+
+/**
+ * @since 1.0.0
+ */
+public class DefaultOAuthStormpathSocialRequestAuthenticatorFactory implements OAuthStormpathSocialRequestAuthenticatorFactory {
+    @Override
+    public OAuthStormpathSocialGrantRequestAuthenticator forApplication(Application application) {
+        return ((DefaultApplication) application).createStormpathSocialGrantAuthenticator();
+    }
+}

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/OAuthStormpathSocialGrantAuthenticationAttempt.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/OAuthStormpathSocialGrantAuthenticationAttempt.java
@@ -12,7 +12,21 @@ public interface OAuthStormpathSocialGrantAuthenticationAttempt extends Resource
      */
     void setGrantType(String grantType);
 
-    void setApiKeyId(String apiKeyId);
+    /**
+     * Method used to set the providerId (e.g. google, facebook, linkedin).
+     * @param providerId the name of the provider
+     */
+    void setProviderId(String providerId);
 
-    void setApiKeySecret(String apiKeySecret);
+    /**
+     * Method used to set the accessToken.
+     * @param accessToken the access token from the social provider. The accessToken or code is required.
+     */
+    void setAccessToken(String accessToken);
+
+    /**
+     * Method used to set the code.
+     * @param code the code from the social provider. The code or accessToken is required.
+     */
+    void setCode(String code);
 }

--- a/impl/src/main/java/com/stormpath/sdk/impl/oauth/OAuthStormpathSocialGrantAuthenticationAttempt.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/oauth/OAuthStormpathSocialGrantAuthenticationAttempt.java
@@ -1,0 +1,18 @@
+package com.stormpath.sdk.impl.oauth;
+
+import com.stormpath.sdk.resource.Resource;
+
+/**
+ * @since 1.0.0
+ */
+public interface OAuthStormpathSocialGrantAuthenticationAttempt extends Resource {
+    /**
+     * Method used to set the Authentication Grant Type that will be used for the token exchange request.
+     * @param grantType the Authentication Grant Type that will be used for the token exchange request.
+     */
+    void setGrantType(String grantType);
+
+    void setApiKeyId(String apiKeyId);
+
+    void setApiKeySecret(String apiKeySecret);
+}

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultCreateOAuthStormpathSocialGrantAuthenticationAttemptTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultCreateOAuthStormpathSocialGrantAuthenticationAttemptTest.groovy
@@ -1,0 +1,47 @@
+package com.stormpath.sdk.impl.oauth
+
+import com.stormpath.sdk.impl.ds.InternalDataStore
+import com.stormpath.sdk.impl.resource.StringProperty
+import org.testng.annotations.Test
+
+import static org.easymock.EasyMock.createStrictMock
+import static org.testng.Assert.assertEquals
+import static org.testng.Assert.assertTrue
+
+/**
+ * @since 1.1.0
+ */
+class DefaultCreateOAuthStormpathSocialGrantAuthenticationAttemptTest {
+
+    @Test
+    void testGetPropertyDescriptors() {
+
+        def defaultCreateGrantAuthAttempt = new DefaultOAuthStormpathSocialGrantAuthenticationAttempt(createStrictMock(InternalDataStore))
+
+        def propertyDescriptors = defaultCreateGrantAuthAttempt.getPropertyDescriptors()
+
+        assertEquals(propertyDescriptors.size(), 3)
+
+        assertTrue(propertyDescriptors.get("apiKeyId") instanceof StringProperty)
+        assertTrue(propertyDescriptors.get("apiKeySecret") instanceof StringProperty)
+        assertTrue(propertyDescriptors.get("grant_type") instanceof StringProperty)
+    }
+
+    @Test
+    void testAuthentication() {
+
+        def properties = [
+                apiKeyId    : "XXXYYY",
+                apiKeySecret: "VVVNNN",
+                grant_type  : "stormpath_social"
+        ]
+
+        def internalDataStore = createStrictMock(InternalDataStore)
+
+        def attempt = new DefaultOAuthStormpathSocialGrantAuthenticationAttempt(internalDataStore, properties)
+
+        assertEquals(attempt.getApiKeyId(), properties.apiKeyId)
+        assertEquals(attempt.getApiKeySecret(), properties.apiKeySecret)
+        assertEquals(attempt.getGrantType(), properties.grant_type)
+    }
+}

--- a/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultCreateOAuthStormpathSocialGrantAuthenticationAttemptTest.groovy
+++ b/impl/src/test/groovy/com/stormpath/sdk/impl/oauth/DefaultCreateOAuthStormpathSocialGrantAuthenticationAttemptTest.groovy
@@ -20,10 +20,11 @@ class DefaultCreateOAuthStormpathSocialGrantAuthenticationAttemptTest {
 
         def propertyDescriptors = defaultCreateGrantAuthAttempt.getPropertyDescriptors()
 
-        assertEquals(propertyDescriptors.size(), 3)
+        assertEquals(propertyDescriptors.size(), 4)
 
-        assertTrue(propertyDescriptors.get("apiKeyId") instanceof StringProperty)
-        assertTrue(propertyDescriptors.get("apiKeySecret") instanceof StringProperty)
+        assertTrue(propertyDescriptors.get("providerId") instanceof StringProperty)
+        assertTrue(propertyDescriptors.get("accessToken") instanceof StringProperty)
+        assertTrue(propertyDescriptors.get("code") instanceof StringProperty)
         assertTrue(propertyDescriptors.get("grant_type") instanceof StringProperty)
     }
 
@@ -31,8 +32,8 @@ class DefaultCreateOAuthStormpathSocialGrantAuthenticationAttemptTest {
     void testAuthentication() {
 
         def properties = [
-                apiKeyId    : "XXXYYY",
-                apiKeySecret: "VVVNNN",
+                providerId  : "facebook",
+                accessToken : "VVVNNN",
                 grant_type  : "stormpath_social"
         ]
 
@@ -40,8 +41,8 @@ class DefaultCreateOAuthStormpathSocialGrantAuthenticationAttemptTest {
 
         def attempt = new DefaultOAuthStormpathSocialGrantAuthenticationAttempt(internalDataStore, properties)
 
-        assertEquals(attempt.getApiKeyId(), properties.apiKeyId)
-        assertEquals(attempt.getApiKeySecret(), properties.apiKeySecret)
+        assertEquals(attempt.getProviderId(), properties.providerId)
+        assertEquals(attempt.getAccessToken(), properties.accessToken)
         assertEquals(attempt.getGrantType(), properties.grant_type)
     }
 }


### PR DESCRIPTION
Fixes #895

To UAT, following these steps:

1. Create a Facebook directory for the application you're testing against. 
2. Use the Facebook Client ID and Client Secret to make a request to Facebook to get an access token.

    ```
    http POST "https://graph.facebook.com/{FACEBOOK_CLIENT_ID}/accounts/test-users?access_token={FACEBOOK_CLIENT_ID}|{FACEBOOK_CLIENT_SECRET}"
    ```

3. Use the access token returned to make a `stormpath_social` request to our OAuth endpoint.

    ```
    http -f POST localhost:8080/oauth/token grant_type=stormpath_social providerId=facebook accessToken=XXX
    ```

You should receive a response with an access token.

For more details, see https://stormpath.atlassian.net/wiki/display/AM/Social+Access+Token+Grant+Type. 

Questions for @omgitstom: the example response on the wiki shows a `refresh_token` and a `stormpath_access_token_href` in the response. Are those required?