### PR TITLE
Disabling login endpoint also disables login functionality

### DIFF
--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebSecurityConfigurer.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebSecurityConfigurer.java
@@ -240,11 +240,11 @@ public class StormpathWebSecurityConfigurer extends SecurityConfigurerAdapter<De
         context.getAutowireCapableBeanFactory().autowireBean(this);
         http.servletApi().rolePrefix(""); //Fix for https://github.com/stormpath/stormpath-sdk-java/issues/325
 
-        if (loginEnabled) {
-            // We need to add the springSecurityResolvedAccountFilter whenever we have our login enabled in order to
-            // fix https://github.com/stormpath/stormpath-sdk-java/issues/450
-            http.addFilterBefore(springSecurityResolvedAccountFilter, AnonymousAuthenticationFilter.class);
+        // We need to add the springSecurityResolvedAccountFilter whenever we have our login enabled in order to
+        // fix https://github.com/stormpath/stormpath-sdk-java/issues/450
+        http.addFilterBefore(springSecurityResolvedAccountFilter, AnonymousAuthenticationFilter.class);
 
+        if (loginEnabled) {
             // This filter replaces http.formLogin() so that we can properly handle content negotiation
             // If it's an HTML request, it delegates to the default UsernamePasswordAuthenticationFilter behavior
             // refer to: https://github.com/stormpath/stormpath-sdk-java/issues/682


### PR DESCRIPTION
Fixes #894

UAT

Using the Spring Security WebMVC Boot example, disable login with `stormpath.web.login.enabled=false`

1. Get an access token from the oauth endpoint
3. Make sure you add the proper group in https://github.com/stormpath/stormpath-sdk-java/blob/master/examples/spring-security-spring-boot-webmvc/src/main/java/com/stormpath/spring/boot/examples/HelloService.java#L29
2. Do a request to /restricted using the access token as authentication 

```
curl -v -s -H "Authorization: bearer ACCESS_TOKEN"  http://localhost:8080/restricted
```

Expected:

1. 200 OK with the HTML of the restricted page content
2. /login should return 404