### PR TITLE
Adding a test and updating doc for servlet init param config

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -76,7 +76,7 @@ If you're just starting out, we recommend that your configuration be specified i
 Defining properties in these locations is covered more in detail next.
 
 1. Plugin web.stormpath.properties
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This file resides in the stormpath-servlet-plugin-|version|.jar at:
 
@@ -103,14 +103,17 @@ If a file ``/WEB-INF/stormpath.properties`` exists in your web application, prop
 4. Servlet Context Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you define ``stormpath.*`` servlet context parameters in your web application's ``/WEB-INF/web.xml`` file, they will override any identically-named properties discovered in previous locations.  For example:
+If you define a block of properties in the ``stormpath.properties`` servlet context parameter in your web application's ``/WEB-INF/web.xml`` file, they will override any identically-named properties discovered in previous locations.  For example:
 
 
 .. code-block:: xml
 
     <context-param>
-        <param-name>stormpath.foo.bar</param-name>
-        <param-value>myValue</param-value>
+        <param-name>stormpath.properties</param-name>
+        <param-value><![CDATA[
+            stormpath.foo.bar = myValue
+            stormpath.other.prop = another value
+        ]]></param-value>
     </context-param>
 
 5. Environment Variables

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
@@ -222,6 +222,31 @@ class DefaultConfigFactoryTest {
         assertEquals 0, config.size()
     }
 
+    /**
+     * Test that properties are loaded from the ServletContext init parameter of 'stormpath.properties'.
+     * @since 1.0.4
+     */
+    @Test
+    public void testServletContextParamProperties() {
+
+        String key1 = "stormpath.test.key1"
+        String value1 = "test.value.result1"
+        String key2 = "stormpath.test.key2"
+        String value2 = "test value result 2"
+
+        def contextProp = """
+            $key1 = $value1
+            $key2 = $value2
+            """
+
+        def servletContext = new MockServletContext()
+        servletContext.setInitParameter("stormpath.properties", contextProp)
+
+        config = new ConfigLoader().createConfig(servletContext)
+        assertEquals config.get(key1), value1
+        assertEquals config.get(key2), value2
+    }
+
     @AfterTest
     public void after() {
         // reset idsite and callback back to defaults


### PR DESCRIPTION
The previous doc mentioned any `stormpath.*` init params would be used, however, only
properties under a single init parameter of `stormpath.properties` are used.