### PR TITLE
Allow the servlet plugin to be disabled by setting `stormpath.enabled = false`

### DIFF
--- a/extensions/servlet/pom.xml
+++ b/extensions/servlet/pom.xml
@@ -85,6 +85,12 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Pulls in HttpClientRequestExecutor implementation for testing in DefaultClientLoaderListenerTest -->
+        <dependency>
+            <groupId>com.stormpath.sdk</groupId>
+            <artifactId>stormpath-sdk-httpclient</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/application/DefaultApplicationLoaderListener.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/application/DefaultApplicationLoaderListener.java
@@ -15,6 +15,9 @@
  */
 package com.stormpath.sdk.servlet.application;
 
+import com.stormpath.sdk.servlet.config.Config;
+import com.stormpath.sdk.servlet.config.ConfigResolver;
+
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
@@ -50,7 +53,10 @@ public class DefaultApplicationLoaderListener extends ApplicationLoader implemen
      */
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        getApplication(sce.getServletContext());
+        Config config = ConfigResolver.INSTANCE.getConfig(sce.getServletContext());
+        if (config.isStormpathEnabled()) {
+            getApplication(sce.getServletContext());
+        }
     }
 
     /**

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/client/ClientLoader.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/client/ClientLoader.java
@@ -29,63 +29,63 @@ import javax.servlet.ServletContext;
  * available in the {@code ServletContext} at application startup.  Once in the {@code ServletContext}, the
  * {@code Client} is available to any application component that needs to interact with Stormpath; these components can
  * can access the {@code client} instance easily, for example:
- * <p>
+ *
  * <pre>
  * (Client)aServletRequest.getAttribute(Client.class.getName());
  * </pre>
- * <p>
+ *
  * <h3>Usage</h3>
- * <p>
+ *
  * <p>This implementation will, without any configuration at all, instantiate and use a
  * {@link DefaultServletContextClientFactory} to build the {@link Client} used by the application.  The
  * {@code DefaultServletContextClientFactory} supports the following {@code context-param} options in your
  * {@code web.xml} configuration: {@code stormpathApiKeyFileLocation} and {@code stormpathClientAuthenticationScheme}.
  * </p>
- * <p>
+ *
  * <h4>{@code stormpathApiKeyFileLocation}</h4>
- * <p>
+ *
  * <p>The {@code stormpathApiKeyFileLocation} {@code context-param}, if present, allows you to specify the resource
  * path to the {@code apiKey.properties} file that should be used to authenticate requests to Stormpath.  For example:</p>
- * <p>
+ *
  * <pre>
  * &lt;context-param&gt;
  *     &lt;param-name&gt;stormpathApiKeyFileLocation&lt;/param-name&gt;
  *     &lt;param-value&gt;/users/whatever/stormpath/apiKey.properties&lt;/param-value&gt;
  * &lt;/context-param&gt;
  * </pre>
- * <p>
+ *
  * <p>You may load files from the filesystem, classpath, or URLs by prefixing the location path with
  * {@code file:}, {@code classpath:}, or {@code url:} respectively.  If no prefix is present, {@code file:}
  * is assumed by default.</p>
- * <p>
+ *
  * <p>If you do not specify this context-param, <code>${user.home}/.stormpath/apiKey.properties</code> is assumed by
  * default.</p>
- * <p>
+ *
  * <h4>{@code stormpathClientAuthenticationScheme}</h4>
- * <p>
+ *
  * <p>The {@code stormpathClientAuthenticationScheme} {@code context-param}, if present, allows you to specify a
  * different HTTP authentication scheme than Stormpath's (very secure) default.  At the moment, the only other
  * alternative is {@code basic}. For example:</p>
- * <p>
+ *
  * <pre>
  * &lt;context-param&gt;
  *     &lt;param-name&gt;stormpathClientAuthenticationScheme&lt;/param-name&gt;
  *     &lt;param-value&gt;basic&lt;/param-value&gt;
  * &lt;/context-param&gt;
  * </pre>
- * <p>
+ *
  * <p><b>Because Stormpath's default authentication scheme is more secure than HTTP Basic authentication, it is
  * strongly recommended that you do not override this value unless you have to</b>.  For example, Google App Engine
  * users will be forced to specify {@code basic} here because GAE's outbound HTTP connection behavior interferes with
  * the default algorithm.  Again, it is not recommended that you use {@code basic} unless you have a technical
  * limitation that prevents you from using Stormpath's default.</p>
- * <p>
+ *
  * <p>If you do not specify this context-param,
  * <a href="http://docs.stormpath.com/rest/product-guide/#authentication-digest"><code>sauthc1</code></a>
  * is assumed by default.</p>
- * <p>
+ *
  * <h4>Custom ServletContextClientFactory Implementation</h4>
- * <p>
+ *
  * <p>As mentioned above, the {@code ClientLoader} assumes the {@code DefaultServletContextClientFactory} behavior
  * (supporting the above two {@code context-param} options) is sufficient for many needs.  If you need to build your
  * application's {@code Client} instance in a custom way - perhaps to enable specific
@@ -93,17 +93,17 @@ import javax.servlet.ServletContext;
  * {@link com.stormpath.sdk.client.Clients#builder() ClientBuilder} - you can implement the
  * {@link ServletContextClientFactory} interface yourself and specify that implementation class name as
  * follows:</p>
- * <p>
+ *
  * <pre>
  * &lt;context-param&gt;
  *     &lt;param-name&gt;stormpathServletContextClientFactoryClass&lt;/param-name&gt;
  *     &lt;param-value&gt;<b>com.mycompany.myapp.stormpath.MyCustomServletContextClientFactory</b>&lt;/param-value&gt;
  * &lt;/context-param&gt;
  * </pre>
- * <p>
+ *
  * <p>If you do not specify this context-param, {@link DefaultServletContextClientFactory
  * com.stormpath.sdk.servlet.client.DefaultServletContextClientFactory} is assumed by default.</p>
- * <p>
+ *
  * <p><b>Because the {@code DefaultServletContextClientFactory} implementation is basic and does not support specifying
  * a custom CacheManager implementation, it is recommended that you create your own
  * {@link ServletContextClientFactory} implementation and specify that class name here for more advanced use cases.

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/client/ClientLoader.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/client/ClientLoader.java
@@ -29,63 +29,63 @@ import javax.servlet.ServletContext;
  * available in the {@code ServletContext} at application startup.  Once in the {@code ServletContext}, the
  * {@code Client} is available to any application component that needs to interact with Stormpath; these components can
  * can access the {@code client} instance easily, for example:
- *
+ * <p>
  * <pre>
  * (Client)aServletRequest.getAttribute(Client.class.getName());
  * </pre>
- *
+ * <p>
  * <h3>Usage</h3>
- *
+ * <p>
  * <p>This implementation will, without any configuration at all, instantiate and use a
  * {@link DefaultServletContextClientFactory} to build the {@link Client} used by the application.  The
  * {@code DefaultServletContextClientFactory} supports the following {@code context-param} options in your
  * {@code web.xml} configuration: {@code stormpathApiKeyFileLocation} and {@code stormpathClientAuthenticationScheme}.
  * </p>
- *
+ * <p>
  * <h4>{@code stormpathApiKeyFileLocation}</h4>
- *
+ * <p>
  * <p>The {@code stormpathApiKeyFileLocation} {@code context-param}, if present, allows you to specify the resource
  * path to the {@code apiKey.properties} file that should be used to authenticate requests to Stormpath.  For example:</p>
- *
+ * <p>
  * <pre>
  * &lt;context-param&gt;
  *     &lt;param-name&gt;stormpathApiKeyFileLocation&lt;/param-name&gt;
  *     &lt;param-value&gt;/users/whatever/stormpath/apiKey.properties&lt;/param-value&gt;
  * &lt;/context-param&gt;
  * </pre>
- *
+ * <p>
  * <p>You may load files from the filesystem, classpath, or URLs by prefixing the location path with
  * {@code file:}, {@code classpath:}, or {@code url:} respectively.  If no prefix is present, {@code file:}
  * is assumed by default.</p>
- *
+ * <p>
  * <p>If you do not specify this context-param, <code>${user.home}/.stormpath/apiKey.properties</code> is assumed by
  * default.</p>
- *
+ * <p>
  * <h4>{@code stormpathClientAuthenticationScheme}</h4>
- *
+ * <p>
  * <p>The {@code stormpathClientAuthenticationScheme} {@code context-param}, if present, allows you to specify a
  * different HTTP authentication scheme than Stormpath's (very secure) default.  At the moment, the only other
  * alternative is {@code basic}. For example:</p>
- *
+ * <p>
  * <pre>
  * &lt;context-param&gt;
  *     &lt;param-name&gt;stormpathClientAuthenticationScheme&lt;/param-name&gt;
  *     &lt;param-value&gt;basic&lt;/param-value&gt;
  * &lt;/context-param&gt;
  * </pre>
- *
+ * <p>
  * <p><b>Because Stormpath's default authentication scheme is more secure than HTTP Basic authentication, it is
  * strongly recommended that you do not override this value unless you have to</b>.  For example, Google App Engine
  * users will be forced to specify {@code basic} here because GAE's outbound HTTP connection behavior interferes with
  * the default algorithm.  Again, it is not recommended that you use {@code basic} unless you have a technical
  * limitation that prevents you from using Stormpath's default.</p>
- *
+ * <p>
  * <p>If you do not specify this context-param,
  * <a href="http://docs.stormpath.com/rest/product-guide/#authentication-digest"><code>sauthc1</code></a>
  * is assumed by default.</p>
- *
+ * <p>
  * <h4>Custom ServletContextClientFactory Implementation</h4>
- *
+ * <p>
  * <p>As mentioned above, the {@code ClientLoader} assumes the {@code DefaultServletContextClientFactory} behavior
  * (supporting the above two {@code context-param} options) is sufficient for many needs.  If you need to build your
  * application's {@code Client} instance in a custom way - perhaps to enable specific
@@ -93,17 +93,17 @@ import javax.servlet.ServletContext;
  * {@link com.stormpath.sdk.client.Clients#builder() ClientBuilder} - you can implement the
  * {@link ServletContextClientFactory} interface yourself and specify that implementation class name as
  * follows:</p>
- *
+ * <p>
  * <pre>
  * &lt;context-param&gt;
  *     &lt;param-name&gt;stormpathServletContextClientFactoryClass&lt;/param-name&gt;
  *     &lt;param-value&gt;<b>com.mycompany.myapp.stormpath.MyCustomServletContextClientFactory</b>&lt;/param-value&gt;
  * &lt;/context-param&gt;
  * </pre>
- *
+ * <p>
  * <p>If you do not specify this context-param, {@link DefaultServletContextClientFactory
  * com.stormpath.sdk.servlet.client.DefaultServletContextClientFactory} is assumed by default.</p>
- *
+ * <p>
  * <p><b>Because the {@code DefaultServletContextClientFactory} implementation is basic and does not support specifying
  * a custom CacheManager implementation, it is recommended that you create your own
  * {@link ServletContextClientFactory} implementation and specify that class name here for more advanced use cases.
@@ -141,7 +141,7 @@ public class ClientLoader {
 
         if (servletContext.getAttribute(CLIENT_ATTRIBUTE_KEY) != null) {
             String msg = "There is already a Stormpath client instance associated with the current ServletContext.  " +
-                         "Check if you have multiple ClientLoader* definitions in your web.xml or annotation config!";
+                    "Check if you have multiple ClientLoader* definitions in your web.xml or annotation config!";
             throw new IllegalStateException(msg);
         }
 
@@ -153,7 +153,7 @@ public class ClientLoader {
         try {
 
             Client client = doCreateClient(servletContext);
-            servletContext.setAttribute(CLIENT_ATTRIBUTE_KEY,client);
+            servletContext.setAttribute(CLIENT_ATTRIBUTE_KEY, client);
 
             log.debug("Published Client as ServletContext attribute with name [{}]", CLIENT_ATTRIBUTE_KEY);
 
@@ -216,10 +216,10 @@ public class ClientLoader {
         Class<?> clazz = determineClientFactoryClass(sc);
         if (!ServletContextClientFactory.class.isAssignableFrom(clazz)) {
             throw new IllegalStateException("Custom ServletContextClientFactory class [" + clazz.getName() +
-                                             "] is not of required type [" + ServletContextClientFactory.class.getName() + "]");
+                    "] is not of required type [" + ServletContextClientFactory.class.getName() + "]");
         }
 
-        ServletContextClientFactory factory = (ServletContextClientFactory)Classes.newInstance(clazz);
+        ServletContextClientFactory factory = (ServletContextClientFactory) Classes.newInstance(clazz);
 
         return factory.createClient(sc);
     }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/client/DefaultClientLoaderListener.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/client/DefaultClientLoaderListener.java
@@ -15,6 +15,9 @@
  */
 package com.stormpath.sdk.servlet.client;
 
+import com.stormpath.sdk.servlet.config.Config;
+import com.stormpath.sdk.servlet.config.ConfigResolver;
+
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
@@ -52,7 +55,10 @@ public class DefaultClientLoaderListener extends ClientLoader implements Servlet
      */
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        createClient(sce.getServletContext());
+        Config config = ConfigResolver.INSTANCE.getConfig(sce.getServletContext());
+        if (config.isStormpathEnabled()) {
+            createClient(sce.getServletContext());
+        }
     }
 
     /**

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/Config.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/Config.java
@@ -89,6 +89,11 @@ public interface Config extends Map<String, String> {
 
     Publisher<RequestEvent> getRequestEventPublisher();
 
+    /**
+     * @since 1.1.0
+     */
+    boolean isStormpathEnabled();
+
     boolean isRegisterAutoLoginEnabled();
 
     /**

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/Config.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/Config.java
@@ -94,6 +94,11 @@ public interface Config extends Map<String, String> {
      */
     boolean isStormpathEnabled();
 
+    /**
+     * @since 1.0.4
+     */
+    boolean isStormpathWebEnabled();
+
     boolean isRegisterAutoLoginEnabled();
 
     /**

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/Config.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/Config.java
@@ -90,7 +90,7 @@ public interface Config extends Map<String, String> {
     Publisher<RequestEvent> getRequestEventPublisher();
 
     /**
-     * @since 1.1.0
+     * @since 1.0.4
      */
     boolean isStormpathEnabled();
 

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/ConfigLoader.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/ConfigLoader.java
@@ -110,14 +110,19 @@ public class ConfigLoader {
             Config config = doCreateConfig(servletContext);
 
             servletContext.setAttribute(CONFIG_ATTRIBUTE_NAME, config);
-            //needed for MessageTag implementation:
+            // needed for MessageTag implementation:
             servletContext.setAttribute(MessageContext.class.getName(), config.getMessageContext());
 
-            log.debug("Published Config as ServletContext attribute with name [{}]", CONFIG_ATTRIBUTE_NAME);
+            // suppress log messages if stormpath disabled
+            if (config.isStormpathEnabled()) {
+                log.debug("Published Config as ServletContext attribute with name [{}]", CONFIG_ATTRIBUTE_NAME);
 
-            if (log.isInfoEnabled()) {
-                long elapsed = System.currentTimeMillis() - startTime;
-                log.info("Stormpath config initialized in {} ms.", elapsed);
+                if (log.isInfoEnabled()) {
+                    long elapsed = System.currentTimeMillis() - startTime;
+                    log.info("Stormpath config initialized in {} ms.", elapsed);
+                }
+            } else {
+                log.info("Stormpath disabled, cancelling initialization.");
             }
 
             return config;

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/DefaultFilterChainManagerConfigurer.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/DefaultFilterChainManagerConfigurer.java
@@ -25,7 +25,6 @@ import com.stormpath.sdk.servlet.config.impl.ExpressionConfigReader;
 import com.stormpath.sdk.servlet.filter.DefaultFilter;
 import com.stormpath.sdk.servlet.filter.FilterChainManager;
 
-import javax.servlet.Filter;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import java.util.LinkedHashMap;
@@ -59,6 +58,10 @@ public class DefaultFilterChainManagerConfigurer {
 
         //Too much copy-and-paste. YUCK.
         //TODO: refactor this method to be more generic
+
+        if (!config.isStormpathEnabled()) {
+            return mgr;
+        }
 
         ConfigReader reader = new ExpressionConfigReader(servletContext, config);
 

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/DefaultFilterChainManagerConfigurer.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/DefaultFilterChainManagerConfigurer.java
@@ -56,12 +56,12 @@ public class DefaultFilterChainManagerConfigurer {
 
     public FilterChainManager configure() throws ServletException {
 
-        //Too much copy-and-paste. YUCK.
-        //TODO: refactor this method to be more generic
-
-        if (!config.isStormpathEnabled()) {
+        if (!config.isStormpathWebEnabled()) {
             return mgr;
         }
+
+        //Too much copy-and-paste. YUCK.
+        //TODO: refactor this method to be more generic
 
         ConfigReader reader = new ExpressionConfigReader(servletContext, config);
 

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/FilterChainManagerFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/FilterChainManagerFactory.java
@@ -40,7 +40,7 @@ public class FilterChainManagerFactory extends ConfigSingletonFactory<FilterChai
         Config config = getConfig();
         DefaultFilterChainManager mgr = new DefaultFilterChainManager(servletContext);
 
-        if (config.isStormpathEnabled()) {
+        if (config.isStormpathWebEnabled()) {
             //add the defaults:
             for (DefaultFilter defaultFilter : DefaultFilter.values()) {
                 Object o = defaultFilter.getFactoryClass();
@@ -70,7 +70,7 @@ public class FilterChainManagerFactory extends ConfigSingletonFactory<FilterChai
                 }
             }
         } else {
-            log.warn("Stormpath disabled, filters not added.");
+            log.warn("Stormpath web support disabled, filters not added.");
         }
 
         return new DefaultFilterChainManagerConfigurer(mgr, servletContext, config).configure();

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/FilterChainManagerFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/FilterChainManagerFactory.java
@@ -21,6 +21,8 @@ import com.stormpath.sdk.servlet.config.ConfigSingletonFactory;
 import com.stormpath.sdk.servlet.filter.DefaultFilter;
 import com.stormpath.sdk.servlet.filter.DefaultFilterChainManager;
 import com.stormpath.sdk.servlet.filter.FilterChainManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContext;
 
@@ -29,42 +31,46 @@ import javax.servlet.ServletContext;
  */
 public class FilterChainManagerFactory extends ConfigSingletonFactory<FilterChainManager> {
 
+    private static final Logger log = LoggerFactory.getLogger(FilterChainManagerFactory.class);
     public static final String FILTER_CONFIG_PREFIX = "stormpath.web.filters.";
 
     @Override
     protected FilterChainManager createInstance(ServletContext servletContext) throws Exception {
 
+        Config config = getConfig();
         DefaultFilterChainManager mgr = new DefaultFilterChainManager(servletContext);
 
-        //add the defaults:
-        for (DefaultFilter defaultFilter : DefaultFilter.values()) {
-            Object o = defaultFilter.getFactoryClass();
-            if (o == null) {
-                o = defaultFilter.getFilterClass();
-            }
-            mgr.addFilter(defaultFilter.name(), o);
-        }
-
-        //pick up any user-configured filterish things as well as allow them to override the defaults:
-        Config config = getConfig();
-
-        for (String key : config.keySet()) {
-
-            if (key.startsWith(FILTER_CONFIG_PREFIX)) {
-
-                String instanceName = key.substring(FILTER_CONFIG_PREFIX.length());
-
-                //if there are any periods in the remainder, then the property is not a class name - it is an
-                // instance-specific config property, so just ignore it:
-                int i = instanceName.indexOf('.');
-                if (i >= 0) {
-                    continue;
+        if (config.isStormpathEnabled()) {
+            //add the defaults:
+            for (DefaultFilter defaultFilter : DefaultFilter.values()) {
+                Object o = defaultFilter.getFactoryClass();
+                if (o == null) {
+                    o = defaultFilter.getFilterClass();
                 }
-
-                String className = config.get(key);
-                Object instance = Classes.newInstance(className);
-                mgr.addFilter(instanceName, instance);
+                mgr.addFilter(defaultFilter.name(), o);
             }
+
+            //pick up any user-configured filterish things as well as allow them to override the defaults:
+            for (String key : config.keySet()) {
+
+                if (key.startsWith(FILTER_CONFIG_PREFIX)) {
+
+                    String instanceName = key.substring(FILTER_CONFIG_PREFIX.length());
+
+                    //if there are any periods in the remainder, then the property is not a class name - it is an
+                    // instance-specific config property, so just ignore it:
+                    int i = instanceName.indexOf('.');
+                    if (i >= 0) {
+                        continue;
+                    }
+
+                    String className = config.get(key);
+                    Object instance = Classes.newInstance(className);
+                    mgr.addFilter(instanceName, instance);
+                }
+            }
+        } else {
+            log.warn("Stormpath disabled, filters not added.");
         }
 
         return new DefaultFilterChainManagerConfigurer(mgr, servletContext, config).configure();

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/SelfConfiguredStormpathFilter.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/SelfConfiguredStormpathFilter.java
@@ -46,7 +46,9 @@ public class SelfConfiguredStormpathFilter extends StormpathFilter {
     protected void onInit() throws ServletException {
         try {
             doInit();
-            super.onInit();
+            if (isEnabled()) {
+                super.onInit();
+            }
         } catch (ServletException e) {
             log.error("Unable to initialize StormpathFilter.", e);
             throw e;
@@ -58,31 +60,31 @@ public class SelfConfiguredStormpathFilter extends StormpathFilter {
     }
 
     protected void doInit() throws ServletException {
-
         ServletContext servletContext = getServletContext();
         Config config = ConfigResolver.INSTANCE.getConfig(servletContext);
+        setEnabled(config.isStormpathEnabled());
 
-        setClient(config.getClient());
-        setApplication(config.getApplicationResolver().getApplication(servletContext));
+        if (isEnabled()) {
+            setClient(config.getClient());
+            setApplication(config.getApplicationResolver().getApplication(servletContext));
 
-        FilterChainResolver resolver = config.getInstance("stormpath.web.filter.chain.resolver");
-        setFilterChainResolver(resolver);
+            FilterChainResolver resolver = config.getInstance("stormpath.web.filter.chain.resolver");
+            setFilterChainResolver(resolver);
 
-        String val = config.get("stormpath.web.request.client.attributeNames");
-        if (Strings.hasText(val)) {
-            String[] vals = Strings.split(val);
-            setClientRequestAttributeNames(new LinkedHashSet<>(Arrays.asList(vals)));
+            String val = config.get("stormpath.web.request.client.attributeNames");
+            if (Strings.hasText(val)) {
+                String[] vals = Strings.split(val);
+                setClientRequestAttributeNames(new LinkedHashSet<>(Arrays.asList(vals)));
+            }
+
+            val = config.get("stormpath.web.request.application.attributeNames");
+            if (Strings.hasText(val)) {
+                String[] vals = Strings.split(val);
+                setApplicationRequestAttributeNames(new LinkedHashSet<>(Arrays.asList(vals)));
+            }
+
+            WrappedServletRequestFactory factory = config.getInstance("stormpath.web.request.factory");
+            setWrappedServletRequestFactory(factory);
         }
-
-        val = config.get("stormpath.web.request.application.attributeNames");
-        if (Strings.hasText(val)) {
-            String[] vals = Strings.split(val);
-            setApplicationRequestAttributeNames(new LinkedHashSet<>(Arrays.asList(vals)));
-        }
-
-        WrappedServletRequestFactory factory = config.getInstance("stormpath.web.request.factory");
-        setWrappedServletRequestFactory(factory);
     }
-
-
 }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/SelfConfiguredStormpathFilter.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/SelfConfiguredStormpathFilter.java
@@ -62,7 +62,7 @@ public class SelfConfiguredStormpathFilter extends StormpathFilter {
     protected void doInit() throws ServletException {
         ServletContext servletContext = getServletContext();
         Config config = ConfigResolver.INSTANCE.getConfig(servletContext);
-        setEnabled(config.isStormpathEnabled());
+        setEnabled(config.isStormpathWebEnabled());
 
         if (isEnabled()) {
             setClient(config.getClient());

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfig.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfig.java
@@ -23,7 +23,6 @@ import com.stormpath.sdk.lang.Assert;
 import com.stormpath.sdk.lang.BiPredicate;
 import com.stormpath.sdk.lang.Classes;
 import com.stormpath.sdk.lang.Strings;
-import com.stormpath.sdk.servlet.authz.RequestAuthorizer;
 import com.stormpath.sdk.servlet.account.AccountResolver;
 import com.stormpath.sdk.servlet.application.ApplicationResolver;
 import com.stormpath.sdk.servlet.client.ClientResolver;
@@ -35,17 +34,13 @@ import com.stormpath.sdk.servlet.config.RegisterEnabledResolver;
 import com.stormpath.sdk.servlet.csrf.CsrfTokenManager;
 import com.stormpath.sdk.servlet.event.RequestEvent;
 import com.stormpath.sdk.servlet.event.impl.Publisher;
-import com.stormpath.sdk.servlet.filter.ServerUriResolver;
-import com.stormpath.sdk.servlet.http.Resolver;
-import com.stormpath.sdk.servlet.http.Saver;
-import com.stormpath.sdk.servlet.http.authc.AccountStoreResolver;
-import com.stormpath.sdk.servlet.idsite.IdSiteOrganizationContext;
 import com.stormpath.sdk.servlet.filter.ChangePasswordConfig;
 import com.stormpath.sdk.servlet.filter.ChangePasswordServletControllerConfig;
 import com.stormpath.sdk.servlet.filter.ContentNegotiationResolver;
 import com.stormpath.sdk.servlet.filter.ControllerConfig;
 import com.stormpath.sdk.servlet.filter.FilterChainManager;
 import com.stormpath.sdk.servlet.filter.FilterChainResolver;
+import com.stormpath.sdk.servlet.filter.ServerUriResolver;
 import com.stormpath.sdk.servlet.filter.ServletControllerConfig;
 import com.stormpath.sdk.servlet.http.InvalidMediaTypeException;
 import com.stormpath.sdk.servlet.http.MediaType;
@@ -55,11 +50,10 @@ import com.stormpath.sdk.servlet.http.authc.AccountStoreResolver;
 import com.stormpath.sdk.servlet.i18n.DefaultMessageContext;
 import com.stormpath.sdk.servlet.i18n.MessageContext;
 import com.stormpath.sdk.servlet.i18n.MessageSource;
+import com.stormpath.sdk.servlet.idsite.IdSiteOrganizationContext;
 import com.stormpath.sdk.servlet.mvc.RequestFieldValueResolver;
 import com.stormpath.sdk.servlet.mvc.WebHandler;
 import com.stormpath.sdk.servlet.util.ServletContextInitializable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -80,28 +74,15 @@ import java.util.regex.Pattern;
  */
 public class DefaultConfig implements Config {
 
-    private static final Logger log = LoggerFactory.getLogger(DefaultConfig.class);
-
     public static final String UNAUTHORIZED_URL = "stormpath.web.unauthorized.uri";
     public static final String LOGOUT_INVALIDATE_HTTP_SESSION = "stormpath.web.logout.invalidateHttpSession";
     public static final String ACCESS_TOKEN_URL = "stormpath.web.oauth2.uri";
     public static final String ACCESS_TOKEN_VALIDATION_STRATEGY = "stormpath.web.oauth2.password.validationStrategy";
-    public static final String ACCESS_TOKEN_AUTHENTICATION_REQUEST_FACTORY =
-            "stormpath.web.oauth2.authenticationRequestFactory";
-    public static final String REFRESH_TOKEN_AUTHENTICATION_REQUEST_FACTORY =
-            "stormpath.web.refreshToken.authenticationRequestFactory";
 
-    public static final String ACCESS_TOKEN_RESULT_FACTORY = "stormpath.web.oauth2.resultFactory";
-    public static final String REFRESH_TOKEN_RESULT_FACTORY = "stormpath.web.refreshToken.resultFactory";
-    public static final String REQUEST_AUTHORIZER = "stormpath.web.oauth2.authorizer";
-    public static final String BASIC_AUTHENTICATION_REQUEST_FACTORY = "stormpath.web.http.authc.schemes.basic";
-    protected static final String UNAUTHENTICATED_HANDLER = "stormpath.web.authc.unauthenticatedHandler";
-    protected static final String UNAUTHORIZED_HANDLER = "stormpath.web.authz.unauthorizedHandler";
     protected static final String SERVER_URI_RESOLVER = "stormpath.web.oauth2.origin.authorizer.serverUriResolver";
     protected static final String IDSITE_ORGANIZATION_RESOLVER_FACTORY = "stormpath.web.idSite.OrganizationResolverFactory";
 
     public static final String WEB_APPLICATION_DOMAIN = "stormpath.web.application.domain";
-
 
     public static final String PRODUCES_MEDIA_TYPES = "stormpath.web.produces";
 
@@ -112,6 +93,7 @@ public class DefaultConfig implements Config {
     public static final String ID_SITE_ENABLED = "stormpath.web.idSite.enabled";
     public static final String CALLBACK_ENABLED = "stormpath.web.callback.enabled";
     public static final String CALLBACK_URI = "stormpath.web.callback.uri";
+    public static final String STORMPATH_ENABLED = "stormpath.enabled";
 
     private final ServletContext servletContext;
     private final ConfigReader CFG;
@@ -250,6 +232,13 @@ public class DefaultConfig implements Config {
     @Override
     public FilterChainResolver getFilterChainResolver() {
         return getRuntimeInstance("stormpath.web.filter.chain.resolver");
+    }
+
+    @Override
+    public boolean isStormpathEnabled() {
+        // get as String in case property not defined
+        String isEnabled = CFG.getString(STORMPATH_ENABLED);
+        return isEnabled == null || CFG.getBoolean(STORMPATH_ENABLED);
     }
 
     @Override

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfig.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfig.java
@@ -94,6 +94,7 @@ public class DefaultConfig implements Config {
     public static final String CALLBACK_ENABLED = "stormpath.web.callback.enabled";
     public static final String CALLBACK_URI = "stormpath.web.callback.uri";
     public static final String STORMPATH_ENABLED = "stormpath.enabled";
+    public static final String STORMPATH_WEB_ENABLED = "stormpath.web.enabled";
 
     private final ServletContext servletContext;
     private final ConfigReader CFG;
@@ -239,6 +240,13 @@ public class DefaultConfig implements Config {
         // get as String in case property not defined
         String isEnabled = CFG.getString(STORMPATH_ENABLED);
         return isEnabled == null || CFG.getBoolean(STORMPATH_ENABLED);
+    }
+
+    @Override
+    public boolean isStormpathWebEnabled() {
+        // get as String in case property not defined
+        String isWebEnabled = CFG.getString(STORMPATH_WEB_ENABLED);
+        return isWebEnabled == null || CFG.getBoolean(STORMPATH_WEB_ENABLED);
     }
 
     @Override

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactory.java
@@ -46,7 +46,6 @@ import java.util.Scanner;
  */
 public class DefaultConfigFactory implements ConfigFactory {
 
-
     public static final String STORMPATH_PROPERTIES         = "stormpath.properties";
     public static final String STORMPATH_PROPERTIES_SOURCES = STORMPATH_PROPERTIES + ".sources";
 

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/StormpathFilter.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/filter/StormpathFilter.java
@@ -19,8 +19,6 @@ import com.stormpath.sdk.application.Application;
 import com.stormpath.sdk.client.Client;
 import com.stormpath.sdk.impl.http.HttpHeadersHolder;
 import com.stormpath.sdk.lang.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -38,8 +36,6 @@ import java.util.Set;
  * @since 1.0.RC3
  */
 public class StormpathFilter extends HttpFilter {
-
-    private static final Logger log = LoggerFactory.getLogger(StormpathFilter.class);
 
     private FilterChainResolver filterChainResolver;
     private Set<String> clientRequestAttributeNames;
@@ -101,7 +97,7 @@ public class StormpathFilter extends HttpFilter {
 
         FilterChainResolver resolver = getFilterChainResolver();
         Assert.notNull(resolver, "Filter has not yet been configured. Explicitly call setFilterChainResolver or " +
-            "init(FilterConfig).");
+                "init(FilterConfig).");
 
         setRequestAttributes(request);
 

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/application/DefaultApplicationLoaderListenerTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/application/DefaultApplicationLoaderListenerTest.groovy
@@ -7,6 +7,7 @@ import com.stormpath.sdk.servlet.config.Config
 import com.stormpath.sdk.servlet.config.ConfigLoader
 import com.stormpath.sdk.servlet.utils.ConfigTestUtils
 import org.springframework.mock.web.MockServletContext
+import org.testng.annotations.AfterMethod
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
@@ -29,8 +30,18 @@ class DefaultApplicationLoaderListenerTest {
         mockServletContext = new MockServletContext()
     }
 
+    @AfterMethod
+    void after() {
+        ConfigTestUtils.setEnv(new HashMap())
+    }
+    
     @Test
     public void testApplicationLoadedByDefault() {
+        Map env = new HashMap()
+        env.put('STORMPATH_API_KEY_ID', '12')
+        env.put('STORMPATH_API_KEY_SECRET', '42')
+        ConfigTestUtils.setEnv(env)
+
         config = new ConfigLoader().createConfig(mockServletContext)
 
         // make ApplicationLoaderListener think a client has already been initialized
@@ -57,7 +68,5 @@ class DefaultApplicationLoaderListenerTest {
 
         new DefaultApplicationLoaderListener().contextInitialized(new ServletContextEvent(mockServletContext))
         assertNull mockServletContext.getAttribute(ApplicationLoader.APP_ATTRIBUTE_NAME)
-
-        ConfigTestUtils.setEnv(new HashMap())
     }
 }

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/application/DefaultApplicationLoaderListenerTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/application/DefaultApplicationLoaderListenerTest.groovy
@@ -17,7 +17,7 @@ import static org.testng.Assert.assertNotNull
 import static org.testng.Assert.assertNull
 
 /**
- * @since 1.1.0
+ * @since 1.0.4
  */
 class DefaultApplicationLoaderListenerTest {
 

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/application/DefaultApplicationLoaderListenerTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/application/DefaultApplicationLoaderListenerTest.groovy
@@ -1,0 +1,63 @@
+package com.stormpath.sdk.servlet.application
+
+import com.stormpath.sdk.application.Application
+import com.stormpath.sdk.impl.client.DefaultClient
+import com.stormpath.sdk.servlet.client.ClientLoader
+import com.stormpath.sdk.servlet.config.Config
+import com.stormpath.sdk.servlet.config.ConfigLoader
+import com.stormpath.sdk.servlet.utils.ConfigTestUtils
+import org.springframework.mock.web.MockServletContext
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import javax.servlet.ServletContextEvent
+
+import static org.easymock.EasyMock.*
+import static org.testng.Assert.assertNotNull
+import static org.testng.Assert.assertNull
+
+/**
+ * @since 1.1.0
+ */
+class DefaultApplicationLoaderListenerTest {
+
+    MockServletContext mockServletContext
+    Config config
+
+    @BeforeMethod
+    void setup() {
+        mockServletContext = new MockServletContext()
+    }
+
+    @Test
+    public void testApplicationLoadedByDefault() {
+        config = new ConfigLoader().createConfig(mockServletContext)
+
+        // make ApplicationLoaderListener think a client has already been initialized
+        DefaultClient defaultClient = createMock(DefaultClient)
+        expect(defaultClient.getResource("http://app", Application.class)).andReturn(createMock(Application))
+        mockServletContext.setAttribute(ClientLoader.CLIENT_ATTRIBUTE_KEY, defaultClient);
+        mockServletContext.setAttribute(DefaultApplicationResolver.STORMPATH_APPLICATION_HREF, "http://app")
+
+        replay defaultClient
+
+        new DefaultApplicationLoaderListener().contextInitialized(new ServletContextEvent(mockServletContext))
+        assertNotNull mockServletContext.getAttribute(ApplicationLoader.APP_ATTRIBUTE_NAME)
+
+        verify defaultClient
+    }
+
+    @Test
+    public void testApplicationLoadingDisabled() {
+        Map<String, String> env = new HashMap<>()
+        env.put('STORMPATH_ENABLED', 'false')
+        ConfigTestUtils.setEnv(env)
+
+        config = new ConfigLoader().createConfig(mockServletContext)
+
+        new DefaultApplicationLoaderListener().contextInitialized(new ServletContextEvent(mockServletContext))
+        assertNull mockServletContext.getAttribute(ApplicationLoader.APP_ATTRIBUTE_NAME)
+
+        ConfigTestUtils.setEnv(new HashMap())
+    }
+}

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/client/DefaultClientLoaderListenerTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/client/DefaultClientLoaderListenerTest.groovy
@@ -13,7 +13,7 @@ import static org.testng.Assert.assertNotNull
 import static org.testng.Assert.assertNull
 
 /**
- * @since 1.1.0
+ * @since 1.0.4
  */
 class DefaultClientLoaderListenerTest {
 

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/client/DefaultClientLoaderListenerTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/client/DefaultClientLoaderListenerTest.groovy
@@ -4,6 +4,7 @@ import com.stormpath.sdk.servlet.config.Config
 import com.stormpath.sdk.servlet.config.ConfigLoader
 import com.stormpath.sdk.servlet.utils.ConfigTestUtils
 import org.springframework.mock.web.MockServletContext
+import org.testng.annotations.AfterMethod
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 
@@ -25,8 +26,18 @@ class DefaultClientLoaderListenerTest {
         mockServletContext = new MockServletContext()
     }
 
+    @AfterMethod
+    void after() {
+        ConfigTestUtils.setEnv(new HashMap())
+    }
+
     @Test
     public void testClientLoadedByDefault() {
+        Map env = new HashMap()
+        env.put('STORMPATH_API_KEY_ID', '12')
+        env.put('STORMPATH_API_KEY_SECRET', '42')
+        ConfigTestUtils.setEnv(env)
+
         config = new ConfigLoader().createConfig(mockServletContext)
 
         new DefaultClientLoaderListener().contextInitialized(new ServletContextEvent(mockServletContext))
@@ -43,7 +54,5 @@ class DefaultClientLoaderListenerTest {
 
         new DefaultClientLoaderListener().contextInitialized(new ServletContextEvent(mockServletContext))
         assertNull mockServletContext.getAttribute(ClientLoader.CLIENT_ATTRIBUTE_KEY)
-
-        ConfigTestUtils.setEnv(new HashMap())
     }
 }

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/client/DefaultClientLoaderListenerTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/client/DefaultClientLoaderListenerTest.groovy
@@ -1,0 +1,49 @@
+package com.stormpath.sdk.servlet.client
+
+import com.stormpath.sdk.servlet.config.Config
+import com.stormpath.sdk.servlet.config.ConfigLoader
+import com.stormpath.sdk.servlet.utils.ConfigTestUtils
+import org.springframework.mock.web.MockServletContext
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import javax.servlet.ServletContextEvent
+
+import static org.testng.Assert.assertNotNull
+import static org.testng.Assert.assertNull
+
+/**
+ * @since 1.1.0
+ */
+class DefaultClientLoaderListenerTest {
+
+    MockServletContext mockServletContext
+    Config config
+
+    @BeforeMethod
+    void setup() {
+        mockServletContext = new MockServletContext()
+    }
+
+    @Test
+    public void testClientLoadedByDefault() {
+        config = new ConfigLoader().createConfig(mockServletContext)
+
+        new DefaultClientLoaderListener().contextInitialized(new ServletContextEvent(mockServletContext))
+        assertNotNull mockServletContext.getAttribute(ClientLoader.CLIENT_ATTRIBUTE_KEY)
+    }
+
+    @Test
+    public void testClientLoadingDisabled() {
+        Map<String, String> env = new HashMap<>()
+        env.put('STORMPATH_ENABLED', 'false')
+        ConfigTestUtils.setEnv(env)
+
+        config = new ConfigLoader().createConfig(mockServletContext)
+
+        new DefaultClientLoaderListener().contextInitialized(new ServletContextEvent(mockServletContext))
+        assertNull mockServletContext.getAttribute(ClientLoader.CLIENT_ATTRIBUTE_KEY)
+
+        ConfigTestUtils.setEnv(new HashMap())
+    }
+}

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/filter/SelfConfiguredStormpathFilterTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/filter/SelfConfiguredStormpathFilterTest.groovy
@@ -1,0 +1,80 @@
+package com.stormpath.sdk.servlet.config.filter
+
+import com.stormpath.sdk.api.ApiKey
+import com.stormpath.sdk.application.Application
+import com.stormpath.sdk.cache.CacheManager
+import com.stormpath.sdk.impl.client.DefaultClient
+import com.stormpath.sdk.servlet.application.DefaultApplicationResolver
+import com.stormpath.sdk.servlet.cache.PropertiesCacheManagerFactory
+import com.stormpath.sdk.servlet.client.ClientLoader
+import com.stormpath.sdk.servlet.config.Config
+import com.stormpath.sdk.servlet.config.ConfigLoader
+import com.stormpath.sdk.servlet.filter.DefaultFilterConfig
+import com.stormpath.sdk.servlet.utils.ConfigTestUtils
+import org.springframework.mock.web.MockServletContext
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import static org.easymock.EasyMock.*
+import static org.testng.Assert.assertFalse
+import static org.testng.Assert.assertTrue
+
+/**
+ * @since 1.1.0
+ */
+class SelfConfiguredStormpathFilterTest {
+
+    MockServletContext mockServletContext
+    Config config
+
+    @BeforeMethod
+    void setup() {
+        mockServletContext = new MockServletContext()
+    }
+
+    @Test
+    public void testStormpathFilterEnabledByDefault() {
+        config = new ConfigLoader().createConfig(mockServletContext)
+
+        // make SelfConfiguredStormpathFilter think a client has already been initialized
+        DefaultClient defaultClient = createMock(DefaultClient)
+        expect(defaultClient.getResource("http://app", Application.class)).andReturn(createMock(Application))
+
+        // create cacheManagerFactory
+        PropertiesCacheManagerFactory factory = new PropertiesCacheManagerFactory();
+        CacheManager cacheManager = factory.createCacheManager(config);
+
+        ApiKey apiKey = createMock(ApiKey)
+        expect(apiKey.getSecret()).andReturn("secret")
+        expect(defaultClient.getCacheManager()).andReturn(cacheManager)
+        expect(defaultClient.getApiKey()).andReturn(apiKey)
+
+        mockServletContext.setAttribute(ClientLoader.CLIENT_ATTRIBUTE_KEY, defaultClient);
+        mockServletContext.setAttribute(DefaultApplicationResolver.STORMPATH_APPLICATION_HREF, "http://app")
+
+        replay apiKey, defaultClient
+
+        SelfConfiguredStormpathFilter filter = new SelfConfiguredStormpathFilter()
+        DefaultFilterConfig filterConfig = new DefaultFilterConfig(mockServletContext, 'filter', null)
+        filter.init(filterConfig)
+        assertTrue filter.isEnabled()
+
+        verify apiKey, defaultClient
+    }
+
+    @Test
+    public void testStormpathFilterDisabled() {
+        Map<String, String> env = new HashMap<>()
+        env.put('STORMPATH_ENABLED', 'false')
+        ConfigTestUtils.setEnv(env)
+
+        config = new ConfigLoader().createConfig(mockServletContext)
+
+        SelfConfiguredStormpathFilter filter = new SelfConfiguredStormpathFilter()
+        DefaultFilterConfig filterConfig = new DefaultFilterConfig(mockServletContext, 'filter', null)
+        filter.init(filterConfig)
+        assertFalse filter.isEnabled()
+
+        ConfigTestUtils.setEnv(new HashMap())
+    }
+}

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/filter/SelfConfiguredStormpathFilterTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/filter/SelfConfiguredStormpathFilterTest.groovy
@@ -65,7 +65,7 @@ class SelfConfiguredStormpathFilterTest {
     @Test
     public void testStormpathFilterDisabled() {
         Map<String, String> env = new HashMap<>()
-        env.put('STORMPATH_ENABLED', 'false')
+        env.put('STORMPATH_WEB_ENABLED', 'false')
         ConfigTestUtils.setEnv(env)
 
         config = new ConfigLoader().createConfig(mockServletContext)

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/filter/SelfConfiguredStormpathFilterTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/filter/SelfConfiguredStormpathFilterTest.groovy
@@ -20,7 +20,7 @@ import static org.testng.Assert.assertFalse
 import static org.testng.Assert.assertTrue
 
 /**
- * @since 1.1.0
+ * @since 1.0.4
  */
 class SelfConfiguredStormpathFilterTest {
 

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/impl/DefaultConfigFactoryTest.groovy
@@ -18,21 +18,14 @@ package com.stormpath.sdk.servlet.config.impl
 import com.stormpath.sdk.lang.Classes
 import com.stormpath.sdk.servlet.config.Config
 import com.stormpath.sdk.servlet.config.ConfigLoader
+import com.stormpath.sdk.servlet.utils.ConfigTestUtils
 import org.springframework.mock.web.MockServletContext
 import org.testng.annotations.AfterTest
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 import org.yaml.snakeyaml.Yaml
 
-import java.lang.reflect.Field
-
-import static org.testng.Assert.assertEquals
-import static org.testng.Assert.assertFalse
-import static org.testng.Assert.assertNull
-import static org.testng.Assert.assertTrue
-import static org.testng.Assert.assertNotNull
-
-
+import static org.testng.Assert.*
 /**
  * @since 1.0.RC9
  */
@@ -47,9 +40,14 @@ class DefaultConfigFactoryTest {
         Map<String, String> env = new HashMap<>()
         env.put('STORMPATH_WEB_IDSITE_ENABLED', 'false')
         env.put('STORMPATH_WEB_CALLBACK_ENABLED', 'true')
-        setEnv(env)
+        ConfigTestUtils.setEnv(env)
         mockServletContext = new MockServletContext()
         config = new ConfigLoader().createConfig(mockServletContext)
+    }
+
+    @Test
+    public void stormpathEnabledByDefault() {
+        assertEquals config.isStormpathEnabled(), true
     }
 
     @Test
@@ -78,7 +76,7 @@ class DefaultConfigFactoryTest {
         Map<String, String> env = new HashMap<>()
         def baseUrl = 'http://env.stormpath.com/v2'
         env.put('STORMPATH_CLIENT_BASEURL', baseUrl)
-        setEnv(env)
+        ConfigTestUtils.setEnv(env)
         config = new ConfigLoader().createConfig(new MockServletContext())
         assertEquals config.get('stormpath.client.baseUrl'), baseUrl
     }
@@ -116,7 +114,7 @@ class DefaultConfigFactoryTest {
         env.put('STORMPATH_WEB_IDSITE_ENABLED', "true")
         env.put('STORMPATH_WEB_CALLBACK_ENABLED', "true")
         env.put('STORMPATH_WEB_ME_ENABLED', "true")
-        setEnv(env)
+        ConfigTestUtils.setEnv(env)
         config = new ConfigLoader().createConfig(new MockServletContext())
 
         assertTrue config.isOAuthEnabled()
@@ -139,7 +137,7 @@ class DefaultConfigFactoryTest {
         Map<String, String> env = new HashMap<>()
         env.put('STORMPATH_WEB_IDSITE_ENABLED', 'true')
         env.put('STORMPATH_WEB_CALLBACK_ENABLED', 'false')
-        setEnv(env)
+        ConfigTestUtils.setEnv(env)
         config = new ConfigLoader().createConfig(new MockServletContext())
     }
 
@@ -228,22 +226,6 @@ class DefaultConfigFactoryTest {
         Map<String, String> env = new HashMap<>()
         env.put('STORMPATH_WEB_IDSITE_ENABLED', 'false')
         env.put('STORMPATH_WEB_CALLBACK_ENABLED', 'true')
-        setEnv(env)
-    }
-
-    // From http://stackoverflow.com/a/496849
-    private static void setEnv(Map<String, String> newenv) throws Exception {
-        Class[] classes = Collections.class.getDeclaredClasses();
-        Map<String, String> env = System.getenv();
-        for (Class cl : classes) {
-            if ('java.util.Collections$UnmodifiableMap'.equals(cl.getName())) {
-                Field field = cl.getDeclaredField('m');
-                field.setAccessible(true);
-                Object obj = field.get(env);
-                Map<String, String> map = (Map<String, String>) obj;
-                map.clear();
-                map.putAll(newenv);
-            }
-        }
+        ConfigTestUtils.setEnv(env)
     }
 }

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/utils/ConfigTestUtils.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/utils/ConfigTestUtils.groovy
@@ -1,0 +1,25 @@
+package com.stormpath.sdk.servlet.utils
+
+import java.lang.reflect.Field
+
+/**
+ * @since 1.1.0
+ */
+class ConfigTestUtils {
+
+    // From http://stackoverflow.com/a/496849
+    static void setEnv(Map<String, String> newenv) throws Exception {
+        Class[] classes = Collections.class.getDeclaredClasses()
+        Map<String, String> env = System.getenv()
+        for (Class cl : classes) {
+            if ('java.util.Collections$UnmodifiableMap'.equals(cl.getName())) {
+                Field field = cl.getDeclaredField('m')
+                field.setAccessible(true)
+                Object obj = field.get(env)
+                Map<String, String> map = (Map<String, String>) obj
+                map.clear()
+                map.putAll(newenv)
+            }
+        }
+    }
+}

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/utils/ConfigTestUtils.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/utils/ConfigTestUtils.groovy
@@ -3,7 +3,7 @@ package com.stormpath.sdk.servlet.utils
 import java.lang.reflect.Field
 
 /**
- * @since 1.1.0
+ * @since 1.0.4
  */
 class ConfigTestUtils {
 


### PR DESCRIPTION
Fixes #871 
Fixes #802

To UAT, run `export STORMPATH_ENABLED=false` and then start examples/servlet. Verify that /login and /registration result in a 404.