### PR TITLE
#966 - enable a couple of account linking tests that were temporarily disabled

### DIFF
--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/application/ApplicationIT.groovy
@@ -1707,7 +1707,7 @@ class ApplicationIT extends ClientIT {
     }
 
     /* @since 1.1.0 */
-    @Test(enabled = false) //TODO: enable this test when AM-3404 from REST API is available in Production
+    @Test
     void testRetrieveAndUpdateAccountLinkingPolicy() {
         def app = createTempApp()
 
@@ -1741,7 +1741,7 @@ class ApplicationIT extends ClientIT {
     }
 
     /* @since 1.1.0 */
-    @Test(enabled = false) //TODO: enable this test when AM-3404 from REST API is available in Production
+    @Test
     void testRetrieveAndUpdateAccountLinkingPolicyPartially() {
         def app = createTempApp()
 

--- a/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/organization/OrganizationIT.groovy
+++ b/extensions/httpclient/src/test/groovy/com/stormpath/sdk/impl/organization/OrganizationIT.groovy
@@ -170,7 +170,7 @@ class OrganizationIT extends ClientIT {
     }
 
     /* @since 1.1.0 */
-    @Test(enabled = false) //TODO: enable this test when AM-3404 from REST API is available in Production
+    @Test
     void testRetrieveAndUpdateAccountLinkingPolicy() {
         def org = client.instantiate(Organization)
         org.setName(uniquify("JSDK_OrganizationIT_testCreateOrganization"))
@@ -212,7 +212,7 @@ class OrganizationIT extends ClientIT {
     }
 
     /* @since 1.1.0 */
-    @Test(enabled = false) //TODO: enable this test when AM-3404 from REST API is available in Production
+    @Test
     void testRetrieveAndUpdateAccountLinkingPolicyPartially() {
         def org = client.instantiate(Organization)
         org.setName(uniquify("JSDK_OrganizationIT_testCreateOrganization"))


### PR DESCRIPTION
A few tests related to Account Linking Policy were disabled temporarily, because relevant REST API changes were not in production yet. The changes are now available since IAM release 121. Therefore, this small PR is just to enable those tests again.