### PR TITLE
Removing unnecessary build steps.

### DIFF
--- a/ci/publish_docs.sh
+++ b/ci/publish_docs.sh
@@ -36,15 +36,3 @@ git add --all
 git commit -m "stormpath-sdk-java release $RELEASE_VERSION"
 ls -la source/java/servlet-plugin
 git push origin source
-gem install bundler
-bundle install
-rake setup_github_pages[git@github.com:stormpath/stormpath.github.io.git]
-cd _deploy
-git pull --no-edit -s recursive -X theirs https://github.com/stormpath/stormpath.github.io.git
-cd ..
-rake generate > /tmp/docs_generate.log
-cd _deploy
-git pull --no-edit -s recursive -X theirs https://github.com/stormpath/stormpath.github.io.git
-cd ..
-rake deploy
-cd ..


### PR DESCRIPTION
This commit simplifies the doc deployment pipeline, and relies on the new deployment stuff I setup internally. This won't break anything, and will help speed up / simplify deploys for docs.