### PR TITLE
Undoing changes introduced by issue 849

### DIFF
--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/AbstractSocialCallbackController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/AbstractSocialCallbackController.java
@@ -75,13 +75,6 @@ public abstract class AbstractSocialCallbackController extends AbstractControlle
 
         eventPublisher.publish(new DefaultSuccessfulAuthenticationRequestEvent(request, response, null, authcResult));
 
-        //Fixes #849 we send in the state the original path the user requested based on the next query param, so we can redirect back
-        String redirectUri = nextUri;
-        String next = ServletUtils.getCleanParam(request, "state");
-        if (Strings.hasText(next)) {
-            redirectUri = next;
-        }
-
-        return new DefaultViewModel(redirectUri).setRedirect(true);
+        return new DefaultViewModel(nextUri).setRedirect(true);
     }
 }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/CallbackController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/CallbackController.java
@@ -106,13 +106,7 @@ public abstract class CallbackController extends AbstractController {
 
         publish(new DefaultSuccessfulAuthenticationRequestEvent(request, response, null, authcResult));
 
-        //Fixes #849 we send in the state the original path the user requested based on the next query param, so we can redirect back
-        String redirectUri = loginNextUri;
-        if (Strings.hasText(result.getState())) {
-            redirectUri = result.getState();
-        }
-
-        return new DefaultViewModel(redirectUri).setRedirect(true);
+        return new DefaultViewModel(loginNextUri).setRedirect(true);
     }
 
     protected ViewModel onLogout(HttpServletRequest request,

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/SamlController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/SamlController.java
@@ -114,7 +114,7 @@ public class SamlController extends AbstractController {
     }
 
     protected String createSamlUrl(HttpServletRequest request) {
-        SamlIdpUrlBuilder builder = createSamlIdpUrlBuilder(request).setState(getNextUri(request));
+        SamlIdpUrlBuilder builder = createSamlIdpUrlBuilder(request);
         return builder.build();
     }
 

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
@@ -83,7 +83,7 @@ class SpecConfigVersusWebPropertiesTest {
             specProperties.containsKey(k) ? null : k
         }
 
-        def expected_diff_size = 82
+        def expected_diff_size = 81
 
         if (diff.size != expected_diff_size) {
             println "It looks like a property was added or removed from the Framework Spec or web.stormpath.properties."

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
@@ -52,10 +52,10 @@ class SpecConfigVersusWebPropertiesTest {
     }
 
     /**
-     * NOTE: This test is temporarily disabled as new properties have been added to the framework spec for
+     * NOTE: This test is temporarily disabled as 15 new properties have been added to the framework spec for
      * multi-tenancy that are not yet implemented in the SDK.
      * Per high priority ticket: https://github.com/stormpath/stormpath-sdk-java/issues/1033,
-     * this should be re-enabled and support for the new properties should be added asap.
+     * Todo: this should be re-enabled and support for the new properties should be added asap
      */
     @Test(enabled=false)
     void verifyPropertiesInSpecAreInDefault() {
@@ -74,9 +74,7 @@ class SpecConfigVersusWebPropertiesTest {
             println "Or you could adjust the assertEquals statement in this method to allow for this missing key as a temporary solution."
         }
 
-        //todo: 15 new properties related to organizations were added to the spec, we do not yet suppor them.
-        //see https://github.com/stormpath/stormpath-sdk-java/issues/1052
-        assertEquals 15, diff.size(), "Missing keys in default config: ${diff}"
+        assertEquals 0, diff.size(), "Missing keys in default config: ${diff}"
     }
 
     @Test

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
@@ -74,7 +74,9 @@ class SpecConfigVersusWebPropertiesTest {
             println "Or you could adjust the assertEquals statement in this method to allow for this missing key as a temporary solution."
         }
 
-        assertEquals 0, diff.size(), "Missing keys in default config: ${diff}"
+        //todo: 15 new properties related to organizations were added to the spec, we do not yet suppor them.
+        //see https://github.com/stormpath/stormpath-sdk-java/issues/1052
+        assertEquals 15, diff.size(), "Missing keys in default config: ${diff}"
     }
 
     @Test
@@ -83,7 +85,7 @@ class SpecConfigVersusWebPropertiesTest {
             specProperties.containsKey(k) ? null : k
         }
 
-        def expected_diff_size = 81
+        def expected_diff_size = 82
 
         if (diff.size != expected_diff_size) {
             println "It looks like a property was added or removed from the Framework Spec or web.stormpath.properties."


### PR DESCRIPTION
Fixes #1040 

This fixes an issue where the `state` property was wrongly treated as `next` uri.