### PR TITLE
Add a Heroku 'Deploy' button to the README.md in the Spring-Boot section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ We also have a [Java WebApp Quickstart](https://docs.stormpath.com/java/servlet-
 
 If you're building a Spring Boot application, the [Spring Boot Webapp Quickstart](https://docs.stormpath.com/java/spring-boot-web/quickstart.html) will get you up and running quickly.
 
+Deploy our Spring Boot Example to Heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-boot-default)
+
 ## Build Instructions
 
 This project requires Maven 3.2.1 and JDK 7 to build.  Run the following:

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,3 +16,27 @@ java -jar target/*.jar
 ```
 
 For more information, refer to the links found on the [homepage](https://github.com/stormpath/stormpath-sdk-java) of the Java SDK Project.
+
+
+Examples:
+
+| Name | Description | Deploy |
+| ---- | ----------- | ------ |
+| [quickstart](./quickstart) | Standalone CLI Example| N/A |
+| [servlet](./servlet) | Basic Servlet Example | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-war-runner&env\[GROUP_ID\]=com.stormpath.sdk&env\[ARTIFACT_ID\]=stormpath-sdk-examples-servlet) |
+| [spring](./spring) | Standalone Spring CLI Example | N/A |
+| [spring-boot](./spring-boot) | Standalone Spring Boot CLI Example | N/A |
+| [spring-boot-default](./spring-boot-default) | Basic Spring Boot Webapp Example | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-boot-default) |
+| [spring-boot-webmvc](./spring-boot-webmvc) | Spring Boot Web MVC Example | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-boot-web) |
+| [spring-boot-webmvc-angular](./spring-boot-webmvc-angular) | Spring Boot Web MVC AngularJS Example | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-boot-web-angular) |
+| [spring-security-spring-boot-webmvc](./spring-security-spring-boot-webmvc) | Spring Security + Spring Boot Web MVC Example | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-security-spring-boot-webmvc) |
+| [spring-security-spring-boot-webmvc-bare-bones](./spring-security-spring-boot-webmvc-bare-bones) | Basic Spring Security Web MVC Example | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-security-spring-boot-webmvc-bare-bones) |
+| [spring-security-webmvc](./spring-security-webmvc) | Spring Security Web MVC Example | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-war-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-security-webmvc) |
+| [spring-webmvc](./spring-webmvc) | Spring Web MVC Example | [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-war-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-webmvc) |
+| [zuul-spring-cloud-starter](./zuul-spring-cloud-starter) | Zuul Spring Cloud Example | N/A |
+
+
+
+
+
+

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,8 @@
+Basic CLI Example
+=================
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn exec:java
+```

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -93,6 +93,22 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.3.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <killAfter>-1</killAfter>
+                    <mainClass>quickstart.Quickstart</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.2</version>

--- a/examples/servlet/README.md
+++ b/examples/servlet/README.md
@@ -1,0 +1,14 @@
+Servlet Example
+===============
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn tomcat7:run
+```
+
+Then visit: http://localhost:8080
+
+Or simply deploy it Heroku with a click of a button!
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-war-runner&env\[GROUP_ID\]=com.stormpath.sdk&env\[ARTIFACT_ID\]=stormpath-sdk-examples-servlet)

--- a/examples/servlet/src/main/webapp/WEB-INF/jsp/welcome.jsp
+++ b/examples/servlet/src/main/webapp/WEB-INF/jsp/welcome.jsp
@@ -28,12 +28,12 @@
                 <br/>
                 <br/>
                 Welcome to this <i>gloriously simple</i>
-                <a href="https://github.com/stormpath/stormpath-sdk-java/extensions/servlet">Stormpath Web</a> sample
+                <a href="https://github.com/stormpath/stormpath-sdk-java/tree/master/extensions/servlet">Stormpath Web</a> sample
                 application!
             <ul>
                 <li>First, take a look through this very basic site.</li>
                 <li>Then, check out this project's source code <a
-                        href="https://github.com/stormpath/stormpath-sdk-java/examples/servlet">on GitHub</a>.
+                        href="https://github.com/stormpath/stormpath-sdk-java/tree/master/examples/servlet">on GitHub</a>.
                 </li>
                 <li>Lastly, integrate Stormpath into your own sites!</li>
             </ul>

--- a/examples/servlet/src/main/webapp/WEB-INF/web.xml
+++ b/examples/servlet/src/main/webapp/WEB-INF/web.xml
@@ -41,6 +41,13 @@
             <max-age>3600</max-age>
         </cookie-config>
     </session-config>
+
+    <!-- Enable servlets as welcome files, only needed for jetty, Tomcat works out of the box -->
+    <context-param>
+        <param-name>org.eclipse.jetty.servlet.Default.welcomeServlets</param-name>
+        <param-value>true</param-value>
+    </context-param>
+
     <welcome-file-list>
         <welcome-file>welcome</welcome-file>
     </welcome-file-list>

--- a/examples/spring-boot-default/README.md
+++ b/examples/spring-boot-default/README.md
@@ -1,0 +1,14 @@
+Spring Boot Web Example
+=======================
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn spring-boot:run
+```
+
+Then visit: http://localhost:8080
+
+Or simply deploy it Heroku with a click of a button!
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-boot-default)

--- a/examples/spring-boot-webmvc-angular/README.md
+++ b/examples/spring-boot-webmvc-angular/README.md
@@ -1,0 +1,14 @@
+Spring Boot AngularJS Example
+=============================
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn spring-boot:run
+```
+
+Then visit: http://localhost:8080
+
+Or simply deploy it Heroku with a click of a button!
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-boot-web-angular)

--- a/examples/spring-boot-webmvc/README.md
+++ b/examples/spring-boot-webmvc/README.md
@@ -1,0 +1,14 @@
+Spring Boot Web MVC Example
+===========================
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn spring-boot:run
+```
+
+Then visit: http://localhost:8080
+
+Or simply deploy it Heroku with a click of a button!
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-boot-web)

--- a/examples/spring-boot/README.md
+++ b/examples/spring-boot/README.md
@@ -1,0 +1,8 @@
+Stand Alone Spring Boot CLI Example
+===================================
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn spring-boot:run
+```

--- a/examples/spring-security-spring-boot-webmvc-bare-bones/README.md
+++ b/examples/spring-security-spring-boot-webmvc-bare-bones/README.md
@@ -1,0 +1,14 @@
+Spring Security & Spring Boot Bare Bones Example
+================================================
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn spring-boot:run
+```
+
+Then visit: http://localhost:8080
+
+Or simply deploy it Heroku with a click of a button!
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-security-spring-boot-webmvc-bare-bones)

--- a/examples/spring-security-spring-boot-webmvc/README.md
+++ b/examples/spring-security-spring-boot-webmvc/README.md
@@ -1,0 +1,14 @@
+Spring Security & Spring Boot Example
+=====================================
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn spring-boot:run
+```
+
+Then visit: http://localhost:8080
+
+Or simply deploy it Heroku with a click of a button!
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-spring-boot-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-security-spring-boot-webmvc)

--- a/examples/spring-security-webmvc/README.md
+++ b/examples/spring-security-webmvc/README.md
@@ -1,0 +1,14 @@
+Spring Security Web MVC Example
+===============================
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn tomcat7:run
+```
+
+Then visit: http://localhost:8080
+
+Or simply deploy it Heroku with a click of a button!
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-war-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-security-webmvc)

--- a/examples/spring-webmvc/README.md
+++ b/examples/spring-webmvc/README.md
@@ -1,0 +1,14 @@
+Spring Boot Web MVC Example
+===========================
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn tomcat7:run
+```
+
+Then visit: http://localhost:8080
+
+Or simply deploy it Heroku with a click of a button!
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/stormpath/heroku-war-runner&env\[GROUP_ID\]=com.stormpath.spring&env\[ARTIFACT_ID\]=stormpath-sdk-examples-spring-webmvc)

--- a/examples/spring/README.md
+++ b/examples/spring/README.md
@@ -1,0 +1,8 @@
+Stand Alone Spring CLI Example
+==============================
+
+Run this example locally with the following Maven command:
+
+``` bash
+$ mvn exec:java
+```


### PR DESCRIPTION
My intent is to add README's for each example, with deploy buttons for all of our war and Spring Boot applications.

For details on how this works you can take a look at:
https://github.com/stormpath/heroku-spring-boot-runner/blob/master/README.md

I want feedback on this idea before spending time on it, Until then, try out this button as an example.
