### PR TITLE
Enforce that Stormpath Java SDK must be built with Maven 3.3.9+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
+before_install:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
+  - unzip -qq apache-maven-3.3.9-bin.zip
+  - export M2_HOME=$PWD/apache-maven-3.3.9
+  - export PATH=$M2_HOME/bin:$PATH
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
-before_install:
-  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
-  - unzip -qq apache-maven-3.3.9-bin.zip
-  - export M2_HOME=$PWD/apache-maven-3.3.9
-  - export PATH=$M2_HOME/bin:$PATH
 addons:
   apt:
     packages:

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -13,10 +13,16 @@ export RELEASE_VERSION="$(xmllint --xpath "//*[local-name()='project']/*[local-n
 export IS_RELEASE="$([ ${RELEASE_VERSION/SNAPSHOT} == $RELEASE_VERSION ] && [ $TRAVIS_BRANCH == 'master' ] && echo 'true')"
 export BUILD_DOCS="$([ $TRAVIS_JDK_VERSION == 'oraclejdk8' ] && echo 'true')"
 export RUN_ITS="$([ $TRAVIS_JDK_VERSION == 'openjdk7' ] && echo 'true')"
+#Install Maven 3.3.9 since Travis uses 3.2 by default
+wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
+unzip -qq apache-maven-3.3.9-bin.zip
+export M2_HOME=$PWD/apache-maven-3.3.9
+export PATH=$M2_HOME/bin:$PATH
 
 info "Build configuration:"
 echo "Version:             $RELEASE_VERSION"
 echo "Is release:          ${IS_RELEASE:-false}"
 echo "Build documentation: ${BUILD_DOCS:-false}"
+echo "Running IT tests:    ${RUN_ITS:-false}"
 echo "Running IT tests:    ${RUN_ITS:-false}"
 

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -16,7 +16,8 @@ export RUN_ITS="$([ $TRAVIS_JDK_VERSION == 'openjdk7' ] && echo 'true')"
 #Install Maven 3.3.9 since Travis uses 3.2 by default
 wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
 unzip -qq apache-maven-3.3.9-bin.zip
-export PATH=$PWD/apache-maven-3.3.9/bin:$PATH
+export M2_HOME=$PWD/apache-maven-3.3.9
+export PATH=$M2_HOME/bin:$PATH
 
 info "Build configuration:"
 echo "Version:             $RELEASE_VERSION"

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -16,13 +16,11 @@ export RUN_ITS="$([ $TRAVIS_JDK_VERSION == 'openjdk7' ] && echo 'true')"
 #Install Maven 3.3.9 since Travis uses 3.2 by default
 wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip
 unzip -qq apache-maven-3.3.9-bin.zip
-export M2_HOME=$PWD/apache-maven-3.3.9
-export PATH=$M2_HOME/bin:$PATH
+export PATH=$PWD/apache-maven-3.3.9/bin:$PATH
 
 info "Build configuration:"
 echo "Version:             $RELEASE_VERSION"
 echo "Is release:          ${IS_RELEASE:-false}"
 echo "Build documentation: ${BUILD_DOCS:-false}"
-echo "Running IT tests:    ${RUN_ITS:-false}"
 echo "Running IT tests:    ${RUN_ITS:-false}"
 

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -43,18 +43,6 @@
             <version>${logback.version}</version>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -92,9 +92,7 @@
     </modules>
 
     <properties>
-
         <jdk.version>1.7</jdk.version>
-
         <slf4j.version>1.7.21</slf4j.version>
         <hazelcast.version>3.6.4</hazelcast.version>
         <httpClient.version>4.5.2</httpClient.version>
@@ -103,6 +101,7 @@
         <oltu.version>1.0.2</oltu.version>
         <jsp.version>2.3.1</jsp.version>
         <joda-time.version>2.9.4</joda-time.version>
+        <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
         <snakeyaml.version>1.17</snakeyaml.version>
         <servlet.version>3.1.0</servlet.version>
         <spring.version>4.3.2.RELEASE</spring.version>
@@ -124,7 +123,6 @@
 
         <!-- Sample App Dependencies: only required when running a sample app. Not required by SDK users at runtime: -->
         <jstl.version>1.2</jstl.version>
-
     </properties>
 
     <dependencies>
@@ -634,9 +632,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4</version>
+                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-banned-dependencies</id>
@@ -652,6 +649,24 @@
                                 </bannedDependencies>
                             </rules>
                             <fail>true</fail>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <message>You are running an older version of Maven. The Stormpath Java SDK requires at least Maven 3.3.9</message>
+                                    <version>[3.3.9,)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <message>The Stormpath Java SDK requires you build with JDK ${jdk.version}.</message>
+                                    <version>[${jdk.version},1.8]</version>
+                                </requireJavaVersion>
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>
@@ -724,6 +739,7 @@
                 <!-- Issue 84: JDK 8 requires strict HTML.  We'll disable this strictness until we can
                      clean up the HTML source in JavaDoc comments: -->
                 <additionalparam>-Xdoclint:none</additionalparam>
+                <jdk.version>1.7</jdk.version>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -662,10 +662,6 @@
                                     <message>You are running an older version of Maven. The Stormpath Java SDK requires at least Maven 3.3.9</message>
                                     <version>[3.3.9,)</version>
                                 </requireMavenVersion>
-                                <requireJavaVersion>
-                                    <message>The Stormpath Java SDK requires you build with JDK ${jdk.version}.</message>
-                                    <version>[${jdk.version},1.8]</version>
-                                </requireJavaVersion>
                             </rules>
                         </configuration>
                     </execution>
@@ -739,7 +735,6 @@
                 <!-- Issue 84: JDK 8 requires strict HTML.  We'll disable this strictness until we can
                      clean up the HTML source in JavaDoc comments: -->
                 <additionalparam>-Xdoclint:none</additionalparam>
-                <jdk.version>1.7</jdk.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Fixes #1066.

This is to prevent anyone from releasing with Maven < 3.3.9.