### PR TITLE
Added LogoutController config setting for invalidateHttpSession and produces settings.

### DIFF
--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/ControllerFilterFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/ControllerFilterFactory.java
@@ -29,22 +29,22 @@ public abstract class ControllerFilterFactory<T extends AbstractController> exte
     @Override
     protected final ControllerFilter createInstance(ServletContext servletContext, Config config) throws Exception {
 
-        T c = newController();
-        c.setAccountResolver(config.getAccountResolver());
-        c.setContentNegotiationResolver(config.getContentNegotiationResolver());
-        c.setEventPublisher(config.getRequestEventPublisher());
-        c.setLocaleResolver(config.getLocaleResolver());
-        c.setMessageSource(config.getMessageSource());
-        c.setProduces(config.getProducedMediaTypes());
-        c.setApplicationResolver(config.getApplicationResolver());
+        T controller = newController();
+        controller.setAccountResolver(config.getAccountResolver());
+        controller.setContentNegotiationResolver(config.getContentNegotiationResolver());
+        controller.setEventPublisher(config.getRequestEventPublisher());
+        controller.setLocaleResolver(config.getLocaleResolver());
+        controller.setMessageSource(config.getMessageSource());
+        controller.setProduces(config.getProducedMediaTypes());
+        controller.setApplicationResolver(config.getApplicationResolver());
 
-        configure(c, config);
+        configure(controller, config);
 
-        c.init();
+        controller.init();
 
         ControllerFilter filter = new ControllerFilter();
         filter.setProducedMediaTypes(config.getProducedMediaTypes());
-        filter.setController(c);
+        filter.setController(controller);
 
         return filter;
     }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/LogoutFilterFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/LogoutFilterFactory.java
@@ -31,5 +31,10 @@ public class LogoutFilterFactory extends ControllerFilterFactory<LogoutControlle
     @Override
     protected void configure(LogoutController controller, Config config) throws Exception {
         controller.setNextUri(config.getLogoutConfig().getNextUri());
+        /*
+            resolves https://github.com/stormpath/stormpath-sdk-java/issues/1121
+         */
+        controller.setInvalidateHttpSession(config.isLogoutInvalidateHttpSession());
+        controller.setProduces(config.getProducedMediaTypes());
     }
 }


### PR DESCRIPTION
Fixes #1121 

Steps to UAT:

1. Add the following to `stormpath.properties` in the Servlet Example:
    
    `stormpath.web.logout.invalidateHttpSession=false`

2. Start the Servlet Example and hit the `/login` endpoint. Make note of the `JSESSIONID` in the inspector:

    ![image](https://cloud.githubusercontent.com/assets/364562/20503310/f7e620b8-b00f-11e6-988b-fc28ce1f15a8.png)

3. Login (`JSESSIONID` should be the same and you should see `access_token` and `refresh_token` cookies)

    ![image](https://cloud.githubusercontent.com/assets/364562/20503392/5207f940-b010-11e6-815a-d1a270067895.png)

4. Logout, and make note of the `JSESSIONID` in the inspector (it should not have changed from step 2.)

    ![image](https://cloud.githubusercontent.com/assets/364562/20503427/73d26a74-b010-11e6-86e3-2adc464c6093.png)


