### PR TITLE
Issue/1138

### DIFF
--- a/examples/servlet/pom.xml
+++ b/examples/servlet/pom.xml
@@ -116,10 +116,10 @@
                 <configuration>
                     <skip>${skipITs}</skip>
                     <container>
-                        <containerId>tomcat7x</containerId>
+                        <containerId>tomcat8x</containerId>
                         <zipUrlInstaller>
                             <url>
-                                http://repo1.maven.org/maven2/org/apache/tomcat/tomcat/7.0.69/tomcat-7.0.69.zip
+                                http://repo1.maven.org/maven2/org/apache/tomcat/tomcat/8.5.9/tomcat-8.5.9.zip
                             </url>
                         </zipUrlInstaller>
                     </container>

--- a/examples/spring-security-spring-boot-webmvc-bare-bones/pom.xml
+++ b/examples/spring-security-spring-boot-webmvc-bare-bones/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.21</slf4j.version>
         <spring.boot.version>1.4.0.RELEASE</spring.boot.version>
-        <tomcat.version>7.0.59</tomcat.version>
+        <tomcat.version>8.5.9</tomcat.version>
     </properties>
 
     <dependencies>

--- a/examples/spring-security-spring-boot-webmvc/pom.xml
+++ b/examples/spring-security-spring-boot-webmvc/pom.xml
@@ -39,7 +39,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.21</slf4j.version>
         <spring.boot.version>1.4.0.RELEASE</spring.boot.version>
-        <tomcat.version>7.0.59</tomcat.version>
+        <tomcat.version>8.5.9</tomcat.version>
     </properties>
 
     <dependencies>

--- a/examples/spring-security-webmvc/pom.xml
+++ b/examples/spring-security-webmvc/pom.xml
@@ -189,32 +189,44 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.eclipse.jetty</groupId>
-                        <artifactId>jetty-maven-plugin</artifactId>
-                        <version>9.4.0.v20161208</version>
-
+                        <groupId>org.codehaus.cargo</groupId>
+                        <artifactId>cargo-maven2-plugin</artifactId>
+                        <version>1.4.18</version>
                         <configuration>
-                            <scanIntervalSeconds>30</scanIntervalSeconds>
-
-                            <stopPort>8081</stopPort>
-                            <stopKey>STOP</stopKey>
-                            <daemon>true</daemon>
-                            <webApp>
-                                <contextPath>/</contextPath>
-                            </webApp>
+                            <skip>${skipITs}</skip>
+                            <container>
+                                <containerId>tomcat8x</containerId>
+                                <zipUrlInstaller>
+                                    <url>
+                                        http://repo1.maven.org/maven2/org/apache/tomcat/tomcat/8.5.9/tomcat-8.5.9.zip
+                                    </url>
+                                </zipUrlInstaller>
+                            </container>
+                            <deployables>
+                                <deployable>
+                                    <groupId>com.stormpath.spring</groupId>
+                                    <artifactId>stormpath-sdk-examples-spring-security-webmvc</artifactId>
+                                    <properties>
+                                        <context>/</context>
+                                    </properties>
+                                </deployable>
+                            </deployables>
+                            <configuration>
+                                <properties>
+                                    <cargo.tomcat.ajp.port>8010</cargo.tomcat.ajp.port>
+                                </properties>
+                            </configuration>
                         </configuration>
                         <executions>
                             <execution>
-                                <id>start-jetty</id>
+                                <id>start-server</id>
                                 <phase>pre-integration-test</phase>
                                 <goals>
-                                    <!-- stop any previous instance to free up the port -->
-                                    <goal>stop</goal>
                                     <goal>start</goal>
                                 </goals>
                             </execution>
                             <execution>
-                                <id>stop-jetty</id>
+                                <id>stop-server</id>
                                 <phase>post-integration-test</phase>
                                 <goals>
                                     <goal>stop</goal>

--- a/examples/spring-security-webmvc/pom.xml
+++ b/examples/spring-security-webmvc/pom.xml
@@ -189,15 +189,9 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.mortbay.jetty</groupId>
+                        <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
-                        <version>8.1.16.v20140903</version>
-
-                        <!-- https://github.com/stormpath/stormpath-sdk-java/issues/270 -->
-                        <!-- When dropping Java 1.6 support, we can switch to jetty-maven-plugin 9.3.7.v20160115 -->
-                        <!--<groupId>org.eclipse.jetty</groupId>-->
-                        <!--<artifactId>jetty-maven-plugin</artifactId>-->
-                        <!--<version>9.3.7.v20160115</version>-->
+                        <version>9.4.0.v20161208</version>
 
                         <configuration>
                             <scanIntervalSeconds>30</scanIntervalSeconds>

--- a/examples/spring-security-webmvc/pom.xml
+++ b/examples/spring-security-webmvc/pom.xml
@@ -41,7 +41,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <spring.version>4.3.2.RELEASE</spring.version>
         <spring.security.version>4.1.2.RELEASE</spring.security.version>
-        <tomcat.version>7.0.59</tomcat.version>
+        <tomcat.version>8.5.9</tomcat.version>
     </properties>
 
     <dependencies>

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/ChangePasswordController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/ChangePasswordController.java
@@ -28,6 +28,8 @@ import com.stormpath.sdk.servlet.form.Form;
 import com.stormpath.sdk.servlet.http.MediaType;
 import com.stormpath.sdk.servlet.http.Saver;
 import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -42,6 +44,8 @@ import java.util.Map;
  * @since 1.0.RC4
  */
 public class ChangePasswordController extends FormController {
+
+    private static final Logger log = LoggerFactory.getLogger(ChangePasswordController.class);
 
     private String forgotPasswordUri;
     private String loginUri;
@@ -244,14 +248,18 @@ public class ChangePasswordController extends FormController {
                 next = this.nextUri;
             }
         } catch (ResourceException e) {
-            // resolves https://github.com/stormpath/stormpath-sdk-java/issues/1138
             // 404 is invalid, expired or used sptoken
             if (e.getCode() == HttpStatus.SC_NOT_FOUND) {
                 next = this.errorUri;
             } else {
+                // resolves https://github.com/stormpath/stormpath-sdk-java/issues/1138
+                // TODO This breaks i18n. Fix when Stormpath backend returns specific password policy failure codes.
                 ErrorModel errorModel = errorModelFactory.toError(request, e);
                 next = getUri() + "?sptoken=" + sptoken + "&error=" + URLEncoder.encode(errorModel.getMessage(), "UTF-8");
             }
+        } catch (Exception e) {
+            log.error("Caught exception: {}. Redirecting to: {}", e.getMessage(), errorUri, e);
+            next = errorUri;
         }
 
         return new DefaultViewModel(next).setRedirect(true);

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/FormController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/FormController.java
@@ -144,6 +144,7 @@ public abstract class FormController extends AbstractController {
                 error = (ErrorModel) session.getAttribute(SPRING_SECURITY_AUTHENTICATION_FAILED_KEY);
             } else {
                 //Fix for https://github.com/stormpath/stormpath-sdk-java/issues/1138
+                //TODO This breaks i18n. Fix when Stormpath backend returns specific password policy failure codes.
                 error = ErrorModel.builder()
                     .setStatus(HttpStatus.SC_BAD_REQUEST).setMessage(request.getParameter("error")).build();
             }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/FormController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/FormController.java
@@ -30,11 +30,13 @@ import com.stormpath.sdk.servlet.form.DefaultField;
 import com.stormpath.sdk.servlet.form.DefaultForm;
 import com.stormpath.sdk.servlet.form.Field;
 import com.stormpath.sdk.servlet.form.Form;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -130,17 +132,22 @@ public abstract class FormController extends AbstractController {
     @SuppressWarnings("unchecked")
     protected Map<String,?> createModel(HttpServletRequest request, HttpServletResponse response) {
         List<ErrorModel> errors = null;
-        // session null check fixes https://github.com/stormpath/stormpath-sdk-java/issues/908
-        if (request.getParameter("error") != null && request.getSession(false) != null) {
-            //The login page is being re-rendered after an unsuccessful authentication attempt from Spring Security
-            //Fix for https://github.com/stormpath/stormpath-sdk-java/issues/648
-            //See StormpathAuthenticationFailureHandler
+        if (request.getParameter("error") != null) {
             errors = new ArrayList<>();
-            ErrorModel error =
-                (ErrorModel) request.getSession(false).getAttribute(SPRING_SECURITY_AUTHENTICATION_FAILED_KEY);
-            if (error != null) {
-                errors.add(error);
+            ErrorModel error = null;
+            HttpSession session = request.getSession(false);
+            // session null check fixes https://github.com/stormpath/stormpath-sdk-java/issues/908
+            if (session != null && session.getAttribute(SPRING_SECURITY_AUTHENTICATION_FAILED_KEY) != null) {
+                //The login page is being re-rendered after an unsuccessful authentication attempt from Spring Security
+                //Fix for https://github.com/stormpath/stormpath-sdk-java/issues/648
+                //See StormpathAuthenticationFailureHandler
+                error = (ErrorModel) session.getAttribute(SPRING_SECURITY_AUTHENTICATION_FAILED_KEY);
+            } else {
+                //Fix for https://github.com/stormpath/stormpath-sdk-java/issues/1138
+                error = ErrorModel.builder()
+                    .setStatus(HttpStatus.SC_BAD_REQUEST).setMessage(request.getParameter("error")).build();
             }
+            errors.add(error);
         }
         return createModel(request, response, null, errors);
     }

--- a/extensions/spring/boot/stormpath-spring-security-webmvc-spring-boot-starter/pom.xml
+++ b/extensions/spring/boot/stormpath-spring-security-webmvc-spring-boot-starter/pom.xml
@@ -27,10 +27,6 @@
     <name>Stormpath :: Spring :: Boot :: Spring Security :: Web MVC Starter</name>
     <description>Spring Boot WebMVC Starter for Stormpath with Spring Security</description>
 
-    <properties>
-        <tomcat.version>8.5.0</tomcat.version>
-    </properties>
-
     <dependencies>
 
         <dependency>
@@ -57,24 +53,6 @@
             <groupId>com.stormpath.sdk</groupId>
             <artifactId>stormpath-sdk-httpclient</artifactId>
             <scope>runtime</scope>
-        </dependency>
-
-        <!--
-            We need to force Tomcat 7 for the ITs to run in Java 6.
-            Otherwise Tomcat 8.0.15 is used and it throws:
-            javax/servlet/ServletContext : Unsupported major.minor version 51.0
-        -->
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-el</artifactId>
-            <version>${tomcat.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.stormpath.spring</groupId>

--- a/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/pom.xml
+++ b/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/pom.xml
@@ -27,10 +27,6 @@
     <name>Stormpath :: Spring :: Boot :: Web MVC</name>
     <description>Stormpath WebMVC Spring Boot Starter</description>
 
-    <properties>
-        <tomcat.version>7.0.59</tomcat.version>
-    </properties>
-
     <dependencies>
 
         <dependency>
@@ -75,23 +71,6 @@
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
 
-        <!--
-            We need to force Tomcat 7 for the ITs to run in Java 6.
-            Otherwise Tomcat 8.0.15 is used and it throws:
-            javax/servlet/ServletContext : Unsupported major.minor version 51.0
-        -->
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-el</artifactId>
-            <version>${tomcat.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.stormpath.spring</groupId>
             <artifactId>stormpath-spring</artifactId>

--- a/extensions/spring/stormpath-spring-security-webmvc/pom.xml
+++ b/extensions/spring/stormpath-spring-security-webmvc/pom.xml
@@ -27,6 +27,11 @@
     <name>Stormpath :: Spring :: Spring Security :: Web MVC</name>
     <description>Web MVC support for Stormpath-enabled Spring Security applications.</description>
 
+    <properties>
+        <restassured.version>2.9.0</restassured.version>
+        <jsoup.version>1.9.2</jsoup.version>
+    </properties>
+
     <dependencies>
 
         <!-- Required dependencies: -->
@@ -92,6 +97,24 @@
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${restassured.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup.version}</version>
+        </dependency>
+
 
     </dependencies>
 

--- a/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/config/AbstractClientIT.groovy
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/config/AbstractClientIT.groovy
@@ -68,6 +68,8 @@ abstract class AbstractClientIT extends AbstractTestNGSpringContextTests {
         this.resourcesToDelete.add(d)
     }
 
+    // Guerilla Email is disposable email API service
+    // https://www.guerrillamail.com/
     protected GuerillaEmail getGuerrillaEmail() throws IOException {
         String json = get(GUERILLA_MAIL_BASE + "?f=get_email_address").asString()
 

--- a/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/config/AbstractClientIT.groovy
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/config/AbstractClientIT.groovy
@@ -1,0 +1,128 @@
+package com.stormpath.spring.config
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.stormpath.sdk.account.Account
+import com.stormpath.sdk.application.Application
+import com.stormpath.sdk.client.Client
+import com.stormpath.sdk.directory.Directory
+import com.stormpath.sdk.resource.Deletable
+import com.stormpath.spring.model.GuerillaEmail
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests
+import org.testng.annotations.AfterClass
+import org.testng.annotations.BeforeClass
+
+import static com.jayway.restassured.RestAssured.get
+
+/**
+ * @since 1.2.3
+ */
+abstract class AbstractClientIT extends AbstractTestNGSpringContextTests {
+
+    private static final String GUERILLA_MAIL_BASE = "http://api.guerrillamail.com/ajax.php"
+    
+    @Autowired
+    Client client
+
+    @Autowired
+    Application application
+
+    //State shared by these internal tests
+    def password = "Pass123!" + UUID.randomUUID()
+    Account account
+
+    ///Supporting properties and methods
+    List<Deletable> resourcesToDelete
+
+    protected Account createTempAccount(String password) {
+        def username = "foo-account-deleteme-" + UUID.randomUUID()
+        def email = username + "@testmail.stormpath.com"
+        return createTempAccount(username, email, password)
+    }
+
+    protected Account createTempAccount(String username, String email, String password) {
+        Account account = client.instantiate(Account.class)
+        account.setEmail(email)
+        account.setUsername(username)
+        account.setPassword(password)
+        account.setGivenName(username)
+        account.setSurname(username)
+        application.createAccount(account)
+        deleteOnTeardown(account)
+        return account
+    }
+
+    protected Directory createTempDir() {
+        Directory dir = client.instantiate(Directory.class)
+        String name = "foo-dir-deleteme-" + UUID.randomUUID()
+        dir.setName(name)
+        client.createDirectory(dir)
+        deleteOnTeardown(dir)
+        return dir
+    }
+
+    protected void deleteOnTeardown(Deletable d) {
+        this.resourcesToDelete.add(d)
+    }
+
+    protected GuerillaEmail getGuerrillaEmail() throws IOException {
+        String json = get(GUERILLA_MAIL_BASE + "?f=get_email_address").asString()
+
+        ObjectMapper mapper = new ObjectMapper()
+        return mapper.readValue(json, GuerillaEmail)
+    }
+    
+    protected Document retrieveEmail(GuerillaEmail guerillaEmail) {
+        String json = get(GUERILLA_MAIL_BASE + "?f=get_email_list&offset=0&sid_token=" + guerillaEmail.getToken()).asString()
+        ObjectMapper mapper = new ObjectMapper()
+        JsonNode rootNode = mapper.readTree(json)
+        JsonNode emailList = rootNode.path("list")
+
+        String emailId = null
+        int count = 0
+
+        while (emailId == null && count++ < 30) {
+            for (JsonNode emailNode : emailList) {
+                String mailFrom = emailNode.get("mail_from").asText()
+                String localEmailId = emailNode.get("mail_id").asText()
+                if (mailFrom.contains("stormpath.com")) {
+                    emailId = localEmailId
+                    break
+                }
+            }
+            if (emailId == null) { // try retrieving email again
+                Thread.sleep(500)
+                json = get(GUERILLA_MAIL_BASE + "?f=get_email_list&offset=0&sid_token=" + guerillaEmail.getToken()).asString()
+                rootNode = mapper.readTree(json)
+                emailList = rootNode.path("list")
+            }
+        }
+
+        if (emailId == null) { return null }
+
+        // fetch stormpath email content
+        json = get(GUERILLA_MAIL_BASE + "?f=fetch_email&sid_token=" + guerillaEmail.getToken() + "&email_id=" + emailId).asString()
+        rootNode = mapper.readTree(json)
+        String emailBody = rootNode.get("mail_body").asText()
+        return Jsoup.parse(emailBody)
+    }
+
+
+    @BeforeClass
+    void setUp() {
+        resourcesToDelete = []
+        def dir = createTempDir()
+        application.setDefaultAccountStore(dir)
+        account = createTempAccount(password)
+    }
+
+    @AfterClass
+    void tearDown() {
+        def reversed = resourcesToDelete.reverse() //delete in opposite order (cleaner - children deleted before parents)
+        reversed.collect { it.delete() }
+    }
+
+}

--- a/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/config/ChangePasswordIT.groovy
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/config/ChangePasswordIT.groovy
@@ -1,0 +1,102 @@
+package com.stormpath.spring.config
+
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.web.WebAppConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+import javax.servlet.http.HttpServletResponse
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import static org.testng.Assert.assertFalse
+import static org.testng.Assert.assertNotNull
+import static org.testng.Assert.assertTrue
+
+/**
+ * @since 1.2.3
+ */
+@WebAppConfiguration
+@ContextConfiguration(classes = [ChangePasswordTestAppConfig, TwoAppTenantStormpathTestConfiguration])
+class ChangePasswordIT extends AbstractClientIT {
+
+    private MockMvc mvc
+
+    @Autowired
+    WebApplicationContext context
+
+    @BeforeMethod
+    void setup() {
+        mvc = MockMvcBuilders.webAppContextSetup(context)
+            .apply(StormpathMockMvcConfigurers.stormpath())
+            .build()
+    }
+
+    @Test
+    void testChange() {
+
+        // create dummy email
+        def guerillaEmail = getGuerrillaEmail()
+
+        // create temp account with email
+        createTempAccount("foo-account-deleteme-" + UUID.randomUUID(), guerillaEmail.email, "Changeme1")
+
+        mvc
+            .perform(post("/forgot")
+            .param("email", guerillaEmail.email)
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(status().is(HttpServletResponse.SC_MOVED_TEMPORARILY)) //302
+
+        // retrieve email
+        Document email = retrieveEmail(guerillaEmail)
+
+        // extract sptoken
+        Elements hrefs = email.getElementsByTag("a")
+        // should only be one, but wanna be safe
+        String href = null
+        hrefs.each { element ->
+            href = element.attributes().get("href")
+        }
+        assertNotNull href
+        def sptoken = href.substring(href.indexOf("sptoken=") + "sptoken=".length())
+
+        // change password test
+        // default policy is: min=8, max=100, lowercase=1, uppercase=1, numeric=1
+        [
+            "aaa", // too short
+            ("a" * 101), // too long
+            "AAAAAAAA", // no lowercase
+            "aaaaaaaa", // no uppercase
+            "Aaaaaaaa", // no numbers
+
+        ].each { password ->
+            def result = mvc
+                .perform(post("/change")
+                .param("sptoken", sptoken)
+                .param("password", password)
+                .accept(MediaType.TEXT_HTML))
+                .andExpect(status().is(HttpServletResponse.SC_MOVED_TEMPORARILY))
+                .andReturn()
+
+            // we don't want to test for specific error strings as they may change
+            assertTrue result.response.getHeader("location").contains("error=")
+        }
+
+        def result = mvc
+            .perform(post("/change")
+            .param("sptoken", sptoken)
+            .param("password", "ChangeMe2") // good password
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(status().is(HttpServletResponse.SC_MOVED_TEMPORARILY))
+            .andReturn()
+
+        assertFalse result.response.getHeader("location").contains("error=")
+    }
+}

--- a/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/config/ChangePasswordTestAppConfig.groovy
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/config/ChangePasswordTestAppConfig.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stormpath.spring.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.PropertySource
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+
+import static com.stormpath.spring.config.StormpathWebSecurityConfigurer.stormpath
+
+/**
+ * @since 1.2.3
+ */
+@Configuration
+@EnableStormpathWebSecurity
+@PropertySource("classpath:com/stormpath/spring/config/applicationChangePassword.properties")
+class ChangePasswordTestAppConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception { http.apply(stormpath()) }
+}

--- a/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/config/MinimalStormpathSpringSecurityWebMvcConfigurationIT.groovy
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/config/MinimalStormpathSpringSecurityWebMvcConfigurationIT.groovy
@@ -67,7 +67,7 @@ import static org.testng.Assert.*
  */
 @ContextConfiguration(classes = [MinimalStormpathSpringSecurityWebMvcTestAppConfig.class, TwoAppTenantStormpathTestConfiguration.class])
 @WebAppConfiguration
-class MinimalStormpathSpringSecurityWebMvcConfigurationIT extends AbstractTestNGSpringContextTests {
+class MinimalStormpathSpringSecurityWebMvcConfigurationIT extends AbstractClientIT {
 
     private static final Logger log = LoggerFactory.getLogger(MinimalStormpathSpringSecurityWebMvcConfigurationIT)
 
@@ -79,12 +79,6 @@ class MinimalStormpathSpringSecurityWebMvcConfigurationIT extends AbstractTestNG
 
     @Autowired
     CacheManager stormpathCacheManager;
-
-    @Autowired
-    Client client;
-
-    @Autowired
-    Application application;
 
     @Autowired
     Filter stormpathFilter
@@ -112,10 +106,6 @@ class MinimalStormpathSpringSecurityWebMvcConfigurationIT extends AbstractTestNG
 
     @Autowired
     RequestEventPublisher requestEventPublisher
-
-    //State shared by these internal tests
-    def password = "Pass123!" + UUID.randomUUID()
-    Account account
 
     @Test
     void testRequiredBeans() {
@@ -241,50 +231,6 @@ class MinimalStormpathSpringSecurityWebMvcConfigurationIT extends AbstractTestNG
 
         // verify authentication object was not changed, meaning backend was not contacted
         Assert.isTrue(SecurityContextHolder.getContext().getAuthentication().equals(authentication))
-    }
-
-    ///Supporting properties and methods
-
-    List<Deletable> resourcesToDelete;
-
-    private Account createTempAccount(String password) {
-        Account account = client.instantiate(Account.class)
-        String username = "foo-account-deleteme-" + UUID.randomUUID();
-        account.setEmail(username + "@testmail.stormpath.com")
-        account.setUsername(username)
-        account.setPassword(password)
-        account.setGivenName(username)
-        account.setSurname(username)
-        application.createAccount(account)
-        deleteOnTeardown(account)
-        return account
-    }
-
-    protected Directory createTempDir() {
-        Directory dir = client.instantiate(Directory.class)
-        String name = "foo-dir-deleteme-" + UUID.randomUUID();
-        dir.setName(name);
-        client.createDirectory(dir);
-        deleteOnTeardown(dir)
-        return dir
-    }
-
-    protected void deleteOnTeardown(Deletable d) {
-        this.resourcesToDelete.add(d)
-    }
-
-    @BeforeClass
-    public void setUp() {
-        resourcesToDelete = []
-        def dir = createTempDir()
-        application.setDefaultAccountStore(dir)
-        account = createTempAccount(password)
-    }
-
-    @AfterClass
-    public void tearDown() {
-        def reversed = resourcesToDelete.reverse() //delete in opposite order (cleaner - children deleted before parents)
-        reversed.collect { it.delete() }
     }
 
     /**

--- a/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/model/GuerillaEmail.groovy
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/model/GuerillaEmail.groovy
@@ -1,0 +1,48 @@
+package com.stormpath.spring.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * @since 1.2.3
+ */
+public class GuerillaEmail {
+    private String alias
+    private String email
+    private long timestamp
+    private String token
+
+    String getAlias() {
+        return alias
+    }
+
+    void setAlias(String alias) {
+        this.alias = alias
+    }
+
+    String getEmail() {
+        return email
+    }
+
+    @JsonProperty("email_addr")
+    void setEmail(String email) {
+        this.email = email
+    }
+
+    long getTimestamp() {
+        return timestamp
+    }
+
+    @JsonProperty("email_timestamp")
+    void setTimestamp(long timestamp) {
+        this.timestamp = timestamp
+    }
+
+    String getToken() {
+        return token
+    }
+
+    @JsonProperty("sid_token")
+    void setToken(String token) {
+        this.token = token
+    }
+}

--- a/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/model/GuerillaEmail.groovy
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/test/groovy/com/stormpath/spring/model/GuerillaEmail.groovy
@@ -3,9 +3,13 @@ package com.stormpath.spring.model
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
+ * <a href="https://www.guerrillamail.com/">Guerilla Email</a> is a disposable email API service that we use in some ITs
+ * in order to retrieve emails in order to, for example, obtain a password reset token.
+ *
  * @since 1.2.3
  */
 public class GuerillaEmail {
+
     private String alias
     private String email
     private long timestamp

--- a/extensions/spring/stormpath-spring-security-webmvc/src/test/resources/com/stormpath/spring/config/applicationChangePassword.properties
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/test/resources/com/stormpath/spring/config/applicationChangePassword.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2016 Stormpath, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+stormpath.web.csrf.token.enabled = false


### PR DESCRIPTION
Fixes #1138

This is a proposed interim solution until https://stormpath.atlassian.net/browse/AM-3744 is resolved.

@george-hawkins-aa - as you don't have access to our internal Jira system, here's the explanation:

The Stormpath backend does not currently send back different codes for different types of password policy failures. It does send back different messages.

This solution uses the message passed back from Stormpath to display as an error on change password view. The message is specific, such as the below:

![image](https://cloud.githubusercontent.com/assets/364562/21201518/1ea94098-c200-11e6-8f08-8a0f58734685.png)

HOWEVER, this breaks internationalization. Once the backend is returning specific codes for password policy failures, we will be able to implement this in a way that respects internationalization.