### PR TITLE
Updated default for id site callback to be  per framework spec

### DIFF
--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/Config.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/Config.java
@@ -78,6 +78,8 @@ public interface Config extends Map<String, String> {
 
     ControllerConfig getVerifyConfig();
 
+    ControllerConfig getSamlConfig();
+
     ChangePasswordConfig getChangePasswordConfig();
 
     Saver<AuthenticationResult> getAuthenticationResultSaver();

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/DefaultFilterChainManagerConfigurer.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/DefaultFilterChainManagerConfigurer.java
@@ -115,8 +115,8 @@ public class DefaultFilterChainManagerConfigurer {
         String unauthorizedUrlPattern = cleanUri(unauthorizedUrl);
         boolean unauthorizedChainSpecified = false;
 
-        //TODO 542: what is this?
-        String samlUrl = "/saml";
+        //fixed per https://github.com/stormpath/stormpath-sdk-java/issues/1254
+        String samlUrl = config.getSamlConfig().getUri();
         String samlUrlPattern = cleanUri(samlUrl);
         String samlCallbackUrl = config.getCallbackUri();
         String samlCallbackPattern = cleanUri(samlCallbackUrl);

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/LoginFilterFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/LoginFilterFactory.java
@@ -40,6 +40,7 @@ public class LoginFilterFactory extends FormControllerFilterFactory<LoginControl
         controller.setForgotPasswordUri(config.getForgotPasswordConfig().getUri());
         controller.setVerifyEnabled(config.getVerifyConfig().isEnabled());
         controller.setVerifyUri(config.getVerifyConfig().getUri());
+        controller.setSamlUri(config.getSamlConfig().getUri());
         controller.setRegisterEnabledResolver(config.getRegisterEnabledResolver());
         controller.setRegisterUri(config.getRegisterConfig().getUri());
         controller.setLogoutUri(config.getLogoutConfig().getUri());

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfig.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/impl/DefaultConfig.java
@@ -217,6 +217,11 @@ public class DefaultConfig implements Config {
     }
 
     @Override
+    public ControllerConfig getSamlConfig() {
+        return new ServletControllerConfig("saml", this);
+    }
+
+    @Override
     public ChangePasswordConfig getChangePasswordConfig() {
         return new ChangePasswordServletControllerConfig(this, "changePassword");
     }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/LoginController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/LoginController.java
@@ -50,6 +50,7 @@ public class LoginController extends FormController {
     private String verifyUri;
     private String registerUri;
     private String logoutUri;
+    private String samlUri;
     private boolean verifyEnabled = true;
     private boolean forgotPasswordEnabled = true;
     private boolean idSiteEnabled;
@@ -77,6 +78,10 @@ public class LoginController extends FormController {
 
     public void setLogoutUri(String logoutUri) {
         this.logoutUri = logoutUri;
+    }
+
+    public void setSamlUri(String samlUri) {
+        this.samlUri = samlUri;
     }
 
     public void setVerifyEnabled(boolean verifyEnabled) {
@@ -149,6 +154,7 @@ public class LoginController extends FormController {
         Assert.hasText(this.registerUri, "registerUri property cannot be null or empty.");
         Assert.notNull(this.registerEnabledResolver, "registerEnabledResolver cannot be null.");
         Assert.hasText(this.logoutUri, "logoutUri property cannot be null or empty.");
+        Assert.hasText(this.samlUri, "samlUri property cannot be null or empty.");
         Assert.notNull(this.authenticationResultSaver, "authenticationResultSaver property cannot be null.");
         Assert.notNull(this.errorModelFactory, "errorModelFactory cannot be null.");
         Assert.notNull(this.preLoginHandler, "preLoginHandler cannot be null.");
@@ -193,6 +199,7 @@ public class LoginController extends FormController {
             model.put("verifyUri", verifyUri);
             model.put("registerEnabled", registerEnabledResolver.get(request, response));
             model.put("registerUri", registerUri);
+            model.put("samlUri", samlUri);
             model.put("oauthStateToken", UUID.randomUUID().toString());
             String status = request.getParameter("status");
             if (status != null) {

--- a/extensions/servlet/src/main/resources/META-INF/resources/WEB-INF/jsp/stormpath/login.jsp
+++ b/extensions/servlet/src/main/resources/META-INF/resources/WEB-INF/jsp/stormpath/login.jsp
@@ -150,6 +150,7 @@
                 <c:set var="req" value="${pageContext.request}"/>
                 <input type="hidden" id="baseUrl"
                        value="${req.scheme}://${req.serverName}:${req.serverPort}${req.contextPath}"/>
+                <input type="hidden" id="samlUri" value="${samlUri}"/>
             </div>
         </div>
 

--- a/extensions/servlet/src/main/resources/META-INF/resources/assets/js/stormpath.js
+++ b/extensions/servlet/src/main/resources/META-INF/resources/assets/js/stormpath.js
@@ -46,6 +46,10 @@ function baseUrl() {
     return $('#baseUrl').val();
 }
 
+function samlUri() {
+    return $('#samlUri').val();
+}
+
 function linkedinLogin(clientId, scope) {
     scope = scope || 'r_emailaddress r_basicprofile';
     window.location.replace(
@@ -91,7 +95,7 @@ function githubLogin(clientId, scope) {
 }
 
 function samlLogin(href) {
-    window.location.replace(buildUrl(baseUrl() + '/saml', {'href': href}));
+    window.location.replace(buildUrl(baseUrl() + samlUri(), {'href': href}));
 }
 
 function facebookLogin(appId, scope) {

--- a/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/config/web.stormpath.properties
+++ b/extensions/servlet/src/main/resources/com/stormpath/sdk/servlet/config/web.stormpath.properties
@@ -105,6 +105,10 @@ stormpath.web.verifyEmail.form.fields.email.label = stormpath.web.verifyEmail.fo
 stormpath.web.verifyEmail.form.fields.email.placeholder = stormpath.web.verifyEmail.form.fields.email.placeholder
 stormpath.web.verifyEmail.form.fields.email.required = true
 stormpath.web.verifyEmail.form.fields.email.type = text
+
+## default SAML SP initiated endpoint
+stormpath.web.saml.uri = /saml
+
 stormpath.web.login.enabled = true
 # The context-relative path to the login view:
 stormpath.web.login.uri = /login

--- a/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
+++ b/extensions/servlet/src/test/groovy/com/stormpath/sdk/servlet/config/SpecConfigVersusWebPropertiesTest.groovy
@@ -85,7 +85,7 @@ class SpecConfigVersusWebPropertiesTest {
             specProperties.containsKey(k) ? null : k
         }
 
-        def expected_diff_size = 84
+        def expected_diff_size = 85
 
         if (diff.size != expected_diff_size) {
             println "It looks like a property was added or removed from the Framework Spec or web.stormpath.properties."

--- a/extensions/spring/boot/stormpath-thymeleaf-spring-boot-starter/src/main/resources/templates/stormpath/login.html
+++ b/extensions/spring/boot/stormpath-thymeleaf-spring-boot-starter/src/main/resources/templates/stormpath/login.html
@@ -109,6 +109,7 @@
         </div>
         <input type="hidden" id="baseUrl"
                th:value="${#httpServletRequest.scheme + '://' + #httpServletRequest.serverName + ':'+#httpServletRequest.serverPort+#httpServletRequest.contextPath}"/>
+        <input type="hidden" id="samlUri" th:value="@{${samlUri}}"/>
     </div>
 </div>
 

--- a/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/main/java/com/stormpath/spring/boot/autoconfigure/StormpathWebMvcAutoConfiguration.java
+++ b/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/main/java/com/stormpath/spring/boot/autoconfigure/StormpathWebMvcAutoConfiguration.java
@@ -682,6 +682,12 @@ public class StormpathWebMvcAutoConfiguration extends AbstractStormpathWebMvcCon
         return super.stormpathVerifyConfig();
     }
 
+    @Bean
+    @ConditionalOnMissingBean(name = "stormpathSamlConfig")
+    public ControllerConfig stormpathSamlConfig() {
+        return super.stormpathSamlConfig();
+    }
+
     /**
      * @since 1.2.0
      */

--- a/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -322,6 +322,12 @@
       "defaultValue": "stormpath/verify"
     },
     {
+      "name": "stormpath.web.saml.uri",
+      "type": "java.lang.String",
+      "description": "The context-relative path to the saml starting point. When a user clicks a SAML button on the Login view (which is present because you've mapped a Stormpath SAML Directory to your Application), the SAML SP initiated workflow will start from this path",
+      "defaultValue": "/saml"
+    },
+    {
       "name": "stormpath.web.logout.enabled",
       "type": "java.lang.Boolean",
       "description": "Whether or not the Stormpath logout controller is enabled.",

--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathSecurityConfigurerAdapter.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathSecurityConfigurerAdapter.java
@@ -81,4 +81,7 @@ public abstract class AbstractStormpathSecurityConfigurerAdapter extends Securit
     @Value("#{ @environment['stormpath.web.resendVerification.uri'] ?: '/resendVerification' }")
     protected String resendVerificationUri;
 
+    @Value("#{ @environment['stormpath.web.saml.uri'] ?: '/saml' }")
+    protected String samlUri;
+
 }

--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathSecurityConfigurerAdapter.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathSecurityConfigurerAdapter.java
@@ -241,6 +241,8 @@ public class StormpathSecurityConfigurerAdapter extends AbstractStormpathSecurit
 
                 http.authorizeRequests()
                     .antMatchers(loginUriMatch).permitAll()
+                    .antMatchers(samlUri).permitAll()
+                    .antMatchers(samlResultUri).permitAll()
                     .antMatchers(googleCallbackUri).permitAll()
                     .antMatchers(githubCallbackUri).permitAll()
                     .antMatchers(facebookCallbackUri).permitAll()
@@ -263,16 +265,17 @@ public class StormpathSecurityConfigurerAdapter extends AbstractStormpathSecurit
         if (idSiteEnabled || callbackEnabled || stormpathWebEnabled) {
             if (logoutEnabled) {
                 LogoutConfigurer<HttpSecurity> httpSecurityLogoutConfigurer = http
-                        .logout()
-                        .invalidateHttpSession(true)
-                        .logoutUrl(logoutUri);
+                    .logout()
+                    .invalidateHttpSession(true)
+                    .logoutUrl(logoutUri);
 
                 if (!idSiteEnabled) {
                     httpSecurityLogoutConfigurer.logoutSuccessUrl(logoutNextUri);
                 }
 
-                httpSecurityLogoutConfigurer.addLogoutHandler(logoutHandler)
-                                            .and().authorizeRequests().antMatchers(logoutUri).permitAll();
+                httpSecurityLogoutConfigurer
+                    .addLogoutHandler(logoutHandler).and()
+                    .authorizeRequests().antMatchers(logoutUri).permitAll();
             }
 
             if (forgotEnabled) {
@@ -331,5 +334,4 @@ public class StormpathSecurityConfigurerAdapter extends AbstractStormpathSecurit
             }
         }
     }
-
 }

--- a/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathSecurityConfigurerAdapter.java
+++ b/extensions/spring/stormpath-spring-security-webmvc/src/main/java/com/stormpath/spring/config/StormpathSecurityConfigurerAdapter.java
@@ -153,9 +153,13 @@ public class StormpathSecurityConfigurerAdapter extends AbstractStormpathSecurit
     @Value("#{ @environment['stormpath.web.callback.enabled'] ?: true }")
     protected boolean callbackEnabled;
 
-    @Value("#{ @environment['stormpath.web.idSite.resultUri'] ?: '/idSiteResult' }")
+    // both idSiteResultUri and samlResultUri default to `/stormpathCallback`
+    // this is a fix for https://github.com/stormpath/stormpath-sdk-java/issues/1254
+    // TODO - for 2.0.0 release remove stormpath.web.idSite.resultUri and use stormpath.web.callback.uri for both id site and saml
+    @Value("#{ @environment['stormpath.web.idSite.resultUri'] ?: '/stormpathCallback' }")
     protected String idSiteResultUri;
 
+    // TODO - for 2.0.0 release rename variable webCallbackUri
     @Value("#{ @environment['stormpath.web.callback.uri'] ?: '/stormpathCallback' }")
     protected String samlResultUri;
 

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
@@ -157,6 +157,7 @@ import com.stormpath.spring.mvc.LoginControllerConfig;
 import com.stormpath.spring.mvc.LogoutControllerConfig;
 import com.stormpath.spring.mvc.MessageContextRegistrar;
 import com.stormpath.spring.mvc.RegisterControllerConfig;
+import com.stormpath.spring.mvc.SamlControllerConfig;
 import com.stormpath.spring.mvc.RevokeTokenControllerConfig;
 import com.stormpath.spring.mvc.SingleNamedViewResolver;
 import com.stormpath.spring.mvc.SpringMessageSource;
@@ -554,7 +555,7 @@ public abstract class AbstractStormpathWebMvcConfiguration {
             addFilter(mgr, stormpathIdSiteResultController(), "idSiteResult", callbackUri);
         }
         if (callbackEnabled) {
-            addFilter(mgr, stormpathSamlController(), "saml", "/saml"); //TODO: why isn't this a configurable uri?
+            addFilter(mgr, stormpathSamlController(), "saml", stormpathSamlConfig().getUri());
             addFilter(mgr, stormpathSamlResultController(), "samlResult", callbackUri);
         }
         if (meEnabled) {
@@ -978,6 +979,7 @@ public abstract class AbstractStormpathWebMvcConfiguration {
         c.setForgotPasswordUri(stormpathForgotPasswordConfig().getUri());
         c.setVerifyEnabled(stormpathVerifyConfig().isEnabled());
         c.setVerifyUri(stormpathVerifyConfig().getUri());
+        c.setSamlUri(stormpathSamlConfig().getUri());
         c.setRegisterEnabledResolver(stormpathRegisterEnabledResolver());
         c.setRegisterUri(stormpathRegisterConfig().getUri());
         c.setLogoutUri(stormpathLogoutConfig().getUri());
@@ -1137,6 +1139,10 @@ public abstract class AbstractStormpathWebMvcConfiguration {
         c.setAccountStoreResolver(stormpathAccountStoreResolver());
 
         return init(c);
+    }
+
+    public ControllerConfig stormpathSamlConfig() {
+        return new SamlControllerConfig();
     }
 
     public ChangePasswordControllerConfig stormpathChangePasswordConfig() {

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebMvcConfiguration.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/StormpathWebMvcConfiguration.java
@@ -583,6 +583,12 @@ public class StormpathWebMvcConfiguration extends AbstractStormpathWebMvcConfigu
 
     @Bean
     @Override
+    public ControllerConfig stormpathSamlConfig() {
+        return super.stormpathSamlConfig();
+    }
+
+    @Bean
+    @Override
     public ChangePasswordControllerConfig stormpathChangePasswordConfig() {
         return super.stormpathChangePasswordConfig();
     }

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/mvc/SamlControllerConfig.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/mvc/SamlControllerConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stormpath.spring.mvc;
+
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ * @since 1.5.0
+ */
+public class SamlControllerConfig extends AbstractSpringControllerConfig {
+
+    @Value("#{ @environment['stormpath.web.saml.uri'] ?: '/saml' }")
+    protected String samlUri;
+
+    public SamlControllerConfig() {
+        super("saml");
+    }
+
+    // SAML config is only relevant in the context of the LoginController,
+    // so it does not have a view of its own
+    @Override
+    public String getView() {
+        return null;
+    }
+
+    @Override
+    public String getUri() {
+        return samlUri;
+    }
+
+    // SAML config is only relevant in the context of the LoginController,
+    // so it does not have a nextUri of its own
+    @Override
+    public String getNextUri() {
+        return null;
+    }
+
+    // SAML config is only relevant in the context of the LoginController.
+    // It's enabled (or not) based on the account stores mapped to the application.
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes #1254 

NOTE: This PR targets #1238 and was cut from that branch because the fix there is needed for this issue as well.

UAT steps:

### No WebSecurityConfigurerAdapter
1. Start with the `spring-security-spring-boot-webmvc-bare-bones` example
2. ID Site Disabled:
    1. Confirm that email/password login works
    2. Confirm that SAML login works
3. ID Site Enabled:
    1. Confirm that email/password login works
    2. Confirm that SAML login works

Note: The `spring-security-spring-boot-webmvc-bare-bones` example does NOT have a `WebSecurityConfigurerAdapter` defined, so it is a good test case for this fix.

### SAML URI override
For each of the following, use an Application with a SAML directory mapped to it.

1. Start with Servlet Example
    1. Put `stormpath.web.saml.uri=/mySpecialSaml` in `stormpath.properties`
    2. Use the browser's Inspector view to confirm that when you click the SAML button, it links to: `/mySpecialSaml (see example below)
    3. Confirm that SAML login works
2. Start with Spring WebMVC Example
    1. Put `stormpath.web.saml.uri=/mySpecialSaml` in `application.properties`
    2. Use the browser's Inspector view to confirm that when you click the SAML button, it links to: `/mySpecialSaml (see example below)
    3. Confirm that SAML login works
3. Start with Spring Boot Default Example
    1. Put `stormpath.web.saml.uri=/mySpecialSaml` in `application.properties`
    2. Use the browser's Inspector view to confirm that when you click the SAML button, it links to: `/mySpecialSaml (see example below)
    3. Confirm that SAML login works

![image](https://cloud.githubusercontent.com/assets/364562/22314892/92ed7256-e331-11e6-8e26-3c6c89d9e27b.png)
