### PR TITLE
Added pre and post login and register docs. 

### DIFF
--- a/docs/source/login.rst
+++ b/docs/source/login.rst
@@ -104,7 +104,7 @@ Want to validate or modify the form data before it’s handled by us? Then this 
 
 #if( $servlet )
 
-To use a ``loginPreHandler``, you need to define a class that implements ``WebHandler`` and reference it in your
+To use a pre login handler, you need to define a class that implements ``WebHandler`` and reference it in your
 ``stormpath.properties`` file.
 
 .. code-block:: java
@@ -156,13 +156,9 @@ The ``handle`` method of the ``loginPreHandler`` is entered after the user has e
 before they have been authenticated. This affords the opportunity to validate the information that's been entered and
 (potentially) take alternative action than the default.
 
-If the ``handle`` method returns ``true``, the user will be authenticated as normal and the appropriate response is returned.
-For instance, ``true`` can be returned from the ``loginPreHandler``, but if the user's credentials are incorrect, they will
-still receive the error response.
-
-As a general rule of thumb, if the handler returns ``true``, then you would **not** redirect the user to an alternate endpoint.
-If the handler returns ``false``, then you would redirect to an alternate endpoint. If you didn't redirect, the original request
-would terminate without a response.
+If you return ``false`` then the Java SDK will not continue the authentication flow. This gives you the chance to take
+care of that yourself. If you are only manipulating or reading data before it is sent to the backend but you still want
+the regular authentication flow to continue then you need to return ``true``.
 
 .. caution::
 
@@ -186,7 +182,7 @@ Want to run some custom code after a user logs into your site? By defining a ``l
 
 #if( $servlet )
 
-To use a ``loginPostHandler``, you need to define a class that implements ``WebHandler`` and reference it in your
+To use a post login handler, you need to define a class that implements ``WebHandler`` and reference it in your
 ``stormpath.properties`` file.
 
 .. code-block:: java

--- a/docs/source/login.rst
+++ b/docs/source/login.rst
@@ -84,8 +84,8 @@ Remember that the property value is the *name* of a view, and the effective Spri
 
 #end
 
-i18n
-----
+Internationalization (i18n)
+---------------------------
 
 The :ref:`i18n` message keys used in the default login view have names prefixed with ``stormpath.web.login.``:
 
@@ -94,6 +94,159 @@ The :ref:`i18n` message keys used in the default login view have names prefixed 
    :lines: 17-48
 
 For more information on customizing i18n messages and adding bundle files, please see :ref:`i18n`.
+
+.. _login pre-login-handler:
+
+Pre Login Handler
+-----------------
+
+Want to validate or modify the form data before it’s handled by us? Then this is the handler that you want to use!
+
+#if( $servlet )
+
+To use a ``loginPreHandler``, you need to define a class that implements ``WebHandler`` and reference it in your
+``stormpath.properties`` file.
+
+.. code-block:: java
+    :linenos:
+    :emphasize-lines: 9, 11
+
+    package com.stormpath.sdk.examples.servlet;
+
+    ...
+
+    public class PreLoginHandler implements WebHandler {
+        private static final Logger log = LoggerFactory.getLogger(PreLoginHandler.class);
+
+        @Override
+        public boolean handle(HttpServletRequest request, HttpServletResponse response, Account account) {
+            log.debug("----> PreLoginHandler");
+            return true;
+        }
+    }
+
+
+.. code-block:: properties
+    :caption: stormpath.properties
+
+    stormpath.web.login.preHandler=com.stormpath.sdk.examples.servlet.PreLoginHandler
+
+#else
+
+To use a ``loginPrehandler``, you need to define a ``Bean`` that returns a ``WebHandler``:
+
+.. code-block:: java
+    :linenos:
+    :emphasize-lines: 5, 7
+
+    @Bean
+    public WebHandler loginPreHandler() {
+        return new WebHandler() {
+            @Override
+            public boolean handle(HttpServletRequest request, HttpServletResponse response, Account account) {
+                log.debug("----> PreLoginHandler");
+                return true;
+            }
+        };
+    }
+
+#end
+
+The ``handle`` method of the ``loginPreHandler`` is entered after the user has entered their email and password, but
+before they have been authenticated. This affords the opportunity to validate the information that's been entered and
+(potentially) take alternative action than the default.
+
+If the ``handle`` method returns ``true``, the user will be authenticated as normal and the appropriate response is returned.
+For instance, ``true`` can be returned from the ``loginPreHandler``, but if the user's credentials are incorrect, they will
+still receive the error response.
+
+As a general rule of thumb, if the handler returns ``true``, then you would **not** redirect the user to an alternate endpoint.
+If the handler returns ``false``, then you would redirect to an alternate endpoint. If you didn't redirect, the original request
+would terminate without a response.
+
+.. caution::
+
+    It is invalid to both send the user to an alternate endpoint using ``response.sendRedirect("<path>")`` or
+    forward using ``request.getRequestDispatcher("<path>").forward(request, response);`` AND
+    return ``true`` from the handler. You will get an ``IllegalStateException`` as the response will have already been
+    committed because you returned ``true``.
+
+.. _login post-login-handler:
+
+Post Login Handler
+------------------
+
+Want to run some custom code after a user logs into your site? By defining a ``loginPostHandler`` you’re able achieve tasks like:
+
+* Funnel users into a multi-factor authentication workflow.
+* Refresh a user’s third-party services.
+* Calculate the last login time of a user.
+* Prompt a user to complete their profile, or setup billing.
+* etc.
+
+#if( $servlet )
+
+To use a ``loginPostHandler``, you need to define a class that implements ``WebHandler`` and reference it in your
+``stormpath.properties`` file.
+
+.. code-block:: java
+    :linenos:
+    :emphasize-lines: 9, 11
+
+    package com.stormpath.sdk.examples.servlet;
+
+    ...
+
+    public class PostLoginHandler implements WebHandler {
+        private static final Logger log = LoggerFactory.getLogger(PostLoginHandler.class);
+
+        @Override
+        public boolean handle(HttpServletRequest request, HttpServletResponse response, Account account) {
+            log.debug("----> PostLoginHandler");
+            return true;
+        }
+    }
+
+.. code-block:: properties
+    :caption: stormpath.properties
+
+    stormpath.web.login.postHandler=com.stormpath.sdk.examples.servlet.PostLoginHandler
+
+#else
+
+To use a ``loginPosthandler``, you need to define a ``Bean`` that returns a ``WebHandler``:
+
+.. code-block:: java
+    :linenos:
+    :emphasize-lines: 5, 7
+
+    @Bean
+    public WebHandler loginPostHandler() {
+        return new WebHandler() {
+            @Override
+            public boolean handle(HttpServletRequest request, HttpServletResponse response, Account account) {
+                log.debug("----> PostLoginHandler");
+                return true;
+            }
+        };
+    }
+
+#end
+
+The ``handle`` method of the ``loginPostHandler`` is entered after the user has been authenticated.
+
+If the ``handle`` method returns ``true``, processing will proceed as normal.
+
+As a general rule of thumb, if the handler returns ``true``, then you would **not** redirect the user to an alternate endpoint.
+If the handler returns ``false``, then you would redirect to an alternate endpoint. If you didn't redirect, the original request
+would terminate without a response.
+
+.. caution::
+
+    It is invalid to both send the user to an alternate endpoint using ``response.sendRedirect("<path>")`` or
+    forward using ``request.getRequestDispatcher("<path>").forward(request, response);`` AND
+    return ``true`` from the handler. You will get an ``IllegalStateException`` as the response will have already been
+    committed because you returned ``true``.
 
 .. _login events:
 

--- a/docs/source/registration.rst
+++ b/docs/source/registration.rst
@@ -655,6 +655,160 @@ The :ref:`i18n` message keys used in the default register view have names prefix
 For more information on customizing i18n messages and adding bundle files, please see :ref:`i18n`.
 
 
+.. _login pre-register-handler:
+
+Pre Register Handler
+--------------------
+
+Want to validate or modify the form data before it’s handled by us? Then this is the handler that you want to use!
+
+#if( $servlet )
+
+To use a ``registerPreHandler``, you need to define a class that implements ``WebHandler`` and reference it in your
+``stormpath.properties`` file.
+
+.. code-block:: java
+    :linenos:
+    :emphasize-lines: 9, 11
+
+    package com.stormpath.sdk.examples.servlet;
+
+    ...
+
+    public class PreRegisterHandler implements WebHandler {
+        private static final Logger log = LoggerFactory.getLogger(PreRegisterHandler.class);
+
+        @Override
+        public boolean handle(HttpServletRequest request, HttpServletResponse response, Account account) {
+            log.debug("----> PreRegisterHandler");
+            return true;
+        }
+    }
+
+.. code-block:: properties
+    :caption: stormpath.properties
+
+    stormpath.web.register.preHandler=com.stormpath.sdk.examples.servlet.PreRegisterHandler
+
+#else
+
+To use a ``registerPrehandler``, you need to define a ``Bean`` that returns a ``WebHandler``:
+
+.. code-block:: java
+    :linenos:
+    :emphasize-lines: 5, 7
+
+    @Bean
+    public WebHandler registerPreHandler() {
+        return new WebHandler() {
+            @Override
+            public boolean handle(HttpServletRequest request, HttpServletResponse response, Account account) {
+                log.debug("----> PreRegisterHandler");
+                return true;
+            }
+        };
+    }
+
+#end
+
+The ``handle`` method of the ``registerPreHandler`` is entered after the user has entered their registration information, but
+before their registration is completed. This affords the opportunity to validate the information that's been entered and
+(potentially) take alternative action than the default.
+
+If the ``handle`` method returns ``true``, the registration will continue as normal and the appropriate response is returned.
+For instance, ``true`` can be returned from the ``registerPreHandler``, but if validation on the registration fields fail,
+the user will still receive the appropriate error response.
+
+As a general rule of thumb, if the handler returns ``true``, then you would **not** redirect the user to an alternate endpoint.
+If the handler returns ``false``, then you would redirect to an alternate endpoint. If you didn't redirect, the original request
+would terminate without a response.
+
+.. caution::
+
+    It is invalid to both send the user to an alternate endpoint using ``response.sendRedirect("<path>")`` or
+    forward using ``request.getRequestDispatcher("<path>").forward(request, response);`` AND
+    return ``true`` from the handler. You will get an ``IllegalStateException`` as the response will have already been
+    committed because you returned ``true``.
+
+.. _login post-register-handler:
+
+Post Register Handler
+---------------------
+
+Want to run some custom code after a user registers for your site? If so, this is the event you want to handle!
+
+By defining a ``postRegisterHandler`` you’re able to do stuff like:
+
+* Setup Multi-factor authentication for future logins.
+* Send a new user a welcome email.
+* Generate API keys for all new users.
+* Setup Stripe billing.
+* etc.
+
+#if( $servlet )
+
+To use a ``registerPostHandler``, you need to define a class that implements ``WebHandler`` and reference it in your
+``stormpath.properties`` file.
+
+.. code-block:: java
+    :linenos:
+    :emphasize-lines: 9, 11
+
+    package com.stormpath.sdk.examples.servlet;
+
+    ...
+
+    public class PostRegisterHandler implements WebHandler {
+        private static final Logger log = LoggerFactory.getLogger(PostRegisterHandler.class);
+
+        @Override
+        public boolean handle(HttpServletRequest request, HttpServletResponse response, Account account) {
+            log.debug("----> PostRegisterHandler");
+            return true;
+        }
+    }
+
+.. code-block:: properties
+    :caption: stormpath.properties
+
+    stormpath.web.register.postHandler=com.stormpath.sdk.examples.servlet.PostRegisterHandler
+
+#else
+
+To use a ``registerPosthandler``, you need to define a ``Bean`` that returns a ``WebHandler``:
+
+.. code-block:: java
+    :linenos:
+    :emphasize-lines: 5, 7
+
+    @Bean
+    public WebHandler registerPostHandler() {
+        return new WebHandler() {
+            @Override
+            public boolean handle(HttpServletRequest request, HttpServletResponse response, Account account) {
+                log.debug("----> PostRegisterHandler");
+                return true;
+            }
+        };
+    }
+
+#end
+
+The ``handle`` method of the ``registerPostHandler`` is entered after the user's registration has been processed.
+
+If the ``handle`` method returns ``true``, processing will continue as normal.
+
+As a general rule of thumb, if the handler returns ``true``, then you would **not** redirect the user to an alternate endpoint.
+If the handler returns ``false``, then you would redirect to an alternate endpoint. If you didn't redirect, the original request
+would terminate without a response.
+
+.. caution::
+
+    It is invalid to both send the user to an alternate endpoint us ing ``response.sendRedirect("<path>")`` or
+    forward using ``request.getRequestDispatcher("<path>").forward(request, response);`` AND
+    return ``true`` from the handler. You will get an ``IllegalStateException`` as the response will have already been
+    committed because you returned ``true``.
+
 Events
 ------
 

--- a/docs/source/registration.rst
+++ b/docs/source/registration.rst
@@ -664,7 +664,7 @@ Want to validate or modify the form data before it’s handled by us? Then this 
 
 #if( $servlet )
 
-To use a ``registerPreHandler``, you need to define a class that implements ``WebHandler`` and reference it in your
+To use a pre registration handler, you need to define a class that implements ``WebHandler`` and reference it in your
 ``stormpath.properties`` file.
 
 .. code-block:: java
@@ -715,9 +715,9 @@ The ``handle`` method of the ``registerPreHandler`` is entered after the user ha
 before their registration is completed. This affords the opportunity to validate the information that's been entered and
 (potentially) take alternative action than the default.
 
-If the ``handle`` method returns ``true``, the registration will continue as normal and the appropriate response is returned.
-For instance, ``true`` can be returned from the ``registerPreHandler``, but if validation on the registration fields fail,
-the user will still receive the appropriate error response.
+If you return ``false`` then the Java SDK will not continue the registration flow. This gives you the chance to take
+care of that yourself. If you are only manipulating or reading data before it is sent to the backend but you still want
+the regular registration flow to continue then you need to return ``true``.
 
 As a general rule of thumb, if the handler returns ``true``, then you would **not** redirect the user to an alternate endpoint.
 If the handler returns ``false``, then you would redirect to an alternate endpoint. If you didn't redirect, the original request
@@ -747,7 +747,7 @@ By defining a ``postRegisterHandler`` you’re able to do stuff like:
 
 #if( $servlet )
 
-To use a ``registerPostHandler``, you need to define a class that implements ``WebHandler`` and reference it in your
+To use a post registration handler, you need to define a class that implements ``WebHandler`` and reference it in your
 ``stormpath.properties`` file.
 
 .. code-block:: java

--- a/extensions/spring/boot/stormpath-spring-security-spring-boot-starter/pom.xml
+++ b/extensions/spring/boot/stormpath-spring-security-spring-boot-starter/pom.xml
@@ -38,6 +38,12 @@
             <artifactId>stormpath-spring-security</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Testing-only dependencies: -->
         <dependency>
             <groupId>com.stormpath.spring</groupId>

--- a/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/pom.xml
+++ b/extensions/spring/boot/stormpath-webmvc-spring-boot-starter/pom.xml
@@ -72,6 +72,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.stormpath.spring</groupId>
             <artifactId>stormpath-spring</artifactId>
             <type>test-jar</type>

--- a/extensions/spring/cloud/stormpath-zuul-spring-cloud-starter/pom.xml
+++ b/extensions/spring/cloud/stormpath-zuul-spring-cloud-starter/pom.xml
@@ -46,5 +46,10 @@
             <version>${bouncycastle.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fixes #1269 

Added pre and post login and register docs. 

Updated starters to depend on spring-boot-configuration-processor so that additional-spring-configuration-metadata.json is properly processed.

UAT:

1. cd docs
2. ./build.sh

Confirm the Pre and Post Login documentation in the `Login` section for:

* `build/servlet/build/html/login.html`
* `build/spring/build/html/login.html`
* `build/springboot/build/html/login.html`
* `build/sczuul/build/html/login.html`

Note: only the servlet version of the docs differs from the rest

Confirm the Pre and Post Registration documentation in the `Registration` section for:

* `build/servlet/build/html/registration.html`
* `build/spring/build/html/registration.html`
* `build/springboot/build/html/registration.html`
* `build/sczuul/build/html/registration.html`

Note: only the servlet version of the docs differs from the rest
