### PR TITLE
Added static default index page with logout form

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -7,7 +7,7 @@
     <name>Stormpath Java SDK :: BOM</name>
     <description>Stormpath Bill of Materials</description>
     <packaging>pom</packaging>
-    <version>1.5.0</version>
+    <version>1.5.2-SNAPSHOT</version>
 
     <url>https://github.com/stormpath/stormpath-sdk-java</url>
     <organization>

--- a/extensions/spring/boot/stormpath-thymeleaf-spring-boot-starter/src/main/resources/static/index.html
+++ b/extensions/spring/boot/stormpath-thymeleaf-spring-boot-starter/src/main/resources/static/index.html
@@ -23,7 +23,7 @@
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>
-<div class="container">
+<div class="container text-center">
     You've reached the default home page.<br/>
     It can be easily overridden by providing a Controller mapped to "/"
 

--- a/extensions/spring/boot/stormpath-thymeleaf-spring-boot-starter/src/main/resources/static/index.html
+++ b/extensions/spring/boot/stormpath-thymeleaf-spring-boot-starter/src/main/resources/static/index.html
@@ -1,0 +1,37 @@
+<!--/*
+~ Copyright 2016 Stormpath, Inc.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+*/-->
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" type="text/css"/>
+</head>
+<body>
+<div class="container">
+    You've reached the default home page.<br/>
+    It can be easily overridden by providing a Controller mapped to "/"
+
+    <form method="post" action="/logout">
+        <input type="submit" class="btn btn-danger" value="Logout"/>
+    </form>
+</div>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+<script src="//netdna.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #1283 

This is the "simplest thing that will work today".

It solves the problem of having a (static) default view when there's an empty project, such as one created by `start.spring.io`

UAT:

**Basic**:

1) Create a completely empty project that references: `stormpath-default-spring-boot-starter`.
2) Browse to: `http://localhost:8080`
3) You should be redirected to `/login`
4) Login and you should be redirected back to the default static home page that includes a logout button
5) Logout and you should be redirected back to the `/login` page

**Controller Override**:

1) Create a completely empty project that references: `stormpath-default-spring-boot-starter`.
2) Add a Controller that maps `/` as in:

    ```
    @Controller
    public class HomeController {

        @RequestMapping("/")
        public String home() {
            return "home";
        }
    }
    ```

3) Create a simple template in `src/main/resources/templates/home.html` like:

    ```
    <h1>Hi!</h1>
    ```

4) Browse to: `http://localhost:8080`
5) You should be redirected to `/login`
6) Login and you should be redirected back to the home template you created in step 3