### PR TITLE
Remove cookies from /oauth/revoke

### DIFF
--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/RevokeTokenFilterFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/config/filter/RevokeTokenFilterFactory.java
@@ -33,5 +33,6 @@ public class RevokeTokenFilterFactory extends ControllerFilterFactory<RevokeToke
     @Override
     protected void configure(RevokeTokenController controller, Config config) throws Exception {
         controller.setApplicationResolver(config.getApplicationResolver());
+        controller.setAuthenticationResultSaver(config.getAuthenticationResultSaver());
     }
 }

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/RevokeTokenController.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/RevokeTokenController.java
@@ -16,18 +16,16 @@
 package com.stormpath.sdk.servlet.mvc;
 
 import com.stormpath.sdk.application.Application;
+import com.stormpath.sdk.authc.AuthenticationResult;
 import com.stormpath.sdk.http.HttpMethod;
 import com.stormpath.sdk.impl.error.DefaultError;
 import com.stormpath.sdk.lang.Strings;
-import com.stormpath.sdk.oauth.OAuthRequests;
-import com.stormpath.sdk.oauth.OAuthRevocationRequest;
-import com.stormpath.sdk.oauth.OAuthRevocationRequestBuilder;
-import com.stormpath.sdk.oauth.OAuthTokenRevocators;
-import com.stormpath.sdk.oauth.TokenTypeHint;
+import com.stormpath.sdk.oauth.*;
 import com.stormpath.sdk.resource.ResourceException;
 import com.stormpath.sdk.servlet.filter.oauth.OAuthErrorCode;
 import com.stormpath.sdk.servlet.filter.oauth.OAuthException;
 import com.stormpath.sdk.servlet.http.MediaType;
+import com.stormpath.sdk.servlet.http.Saver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,12 +44,18 @@ public class RevokeTokenController extends AbstractController {
     private final static String TOKEN = "token";
     private final static String TOKEN_TYPE_HINT = "token_type_hint";
 
+    private Saver<AuthenticationResult> authenticationResultSaver;
+
     public void init() {
     }
 
     @Override
     public boolean isNotAllowedIfAuthenticated() {
         return false;
+    }
+
+    public void setAuthenticationResultSaver(Saver<AuthenticationResult> authenticationResultSaver) {
+        this.authenticationResultSaver = authenticationResultSaver;
     }
 
     @Override
@@ -95,6 +99,8 @@ public class RevokeTokenController extends AbstractController {
             }
 
             this.revoke(getApplication(request), builder.setToken(token).build());
+
+            authenticationResultSaver.set(request, response, null);
 
             response.setStatus(HttpServletResponse.SC_OK);
             response.setHeader("Content-Length", "0");

--- a/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
+++ b/extensions/spring/stormpath-spring-webmvc/src/main/java/com/stormpath/spring/config/AbstractStormpathWebMvcConfiguration.java
@@ -1225,6 +1225,7 @@ public abstract class AbstractStormpathWebMvcConfiguration {
     public Controller stormpathRevokeTokenController() {
         RevokeTokenController c = new RevokeTokenController();
         c.setApplicationResolver(stormpathApplicationResolver());
+        c.setAuthenticationResultSaver(stormpathAuthenticationResultSaver());
         return init(c);
     }
 


### PR DESCRIPTION
Fixes #1304.

To UAT, login using a password grant:

```
http -f http://localhost:8080/oauth/token username=XYZ password=XXX grant_type=password
```

Use the refresh_token value to logout:

```
http -f http://localhost:8080/oauth/revoke token_type_hint=refresh_token token=XXX
```

You should see cookies being set, whereas there are no cookies set on master.

**examples/servlet**:

```
http -f http://localhost:8080/oauth/revoke token_type_hint=refresh_token token=XXX
HTTP/1.1 200 OK
Cache-Control: no-store, no-cache
Content-Length: 0
Date: Tue, 07 Mar 2017 16:31:09 GMT
Pragma: no-cache
Server: Apache-Coyote/1.1
Set-Cookie: access_token=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly
Set-Cookie: refresh_token=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly
```

**examples/spring-security-spring-boot-webmvc**:

```
http -f http://localhost:8080/oauth/revoke token_type_hint=refresh_token token=XXX
HTTP/1.1 200
Cache-Control: no-store, no-cache
Content-Length: 0
Date: Tue, 07 Mar 2017 16:34:14 GMT
Expires: 0
Pragma: no-cache
Set-Cookie: JSESSIONID=1255715FE2A661AA3F55126EB87C4617;path=/;HttpOnly
Set-Cookie: access_token=;Max-Age=0;path=/;HttpOnly
Set-Cookie: refresh_token=;Max-Age=0;path=/;HttpOnly
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
```