### PR TITLE
Okta Password Policy

### DIFF
--- a/api/src/main/java/com/stormpath/sdk/directory/OktaPasswordPolicy.java
+++ b/api/src/main/java/com/stormpath/sdk/directory/OktaPasswordPolicy.java
@@ -1,0 +1,23 @@
+package com.stormpath.sdk.directory;
+
+import com.stormpath.sdk.resource.Resource;
+
+import java.util.Date;
+import java.util.Map;
+
+public interface OktaPasswordPolicy extends Resource {
+
+    String getType();
+    String getId();
+    String getStatus();
+    String getName();
+    String getDescription();
+    int getPriority();
+    boolean getSystem();
+    Map<String, Object> getConditions();
+    Date getCreated();
+    Date getLastUpdated();
+    Map<String, Object> getSettings();
+    Map<String, Object> getDelegation();
+    Map<String, Object> getRules();
+}

--- a/api/src/main/java/com/stormpath/sdk/directory/OktaPasswordPolicyList.java
+++ b/api/src/main/java/com/stormpath/sdk/directory/OktaPasswordPolicyList.java
@@ -1,0 +1,6 @@
+package com.stormpath.sdk.directory;
+
+import com.stormpath.sdk.resource.CollectionResource;
+
+public interface OktaPasswordPolicyList extends CollectionResource<OktaPasswordPolicy> {
+}

--- a/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/provider/ExternalAccountStoreModelFactory.java
+++ b/extensions/servlet/src/main/java/com/stormpath/sdk/servlet/mvc/provider/ExternalAccountStoreModelFactory.java
@@ -59,11 +59,14 @@ public class ExternalAccountStoreModelFactory implements AccountStoreModelFactor
         AccountStoreModelVisitor visitor =
                 new AccountStoreModelVisitor(accountStores, getAuthorizeBaseUri(request, app.getWebConfig()));
 
-        for (ApplicationAccountStoreMapping mapping : mappings) {
+        // TODO - if introduced for Okta. Need to deal with for real when we add social support
+        if (mappings.getHref() != null) {
+            for (ApplicationAccountStoreMapping mapping : mappings) {
 
-            final AccountStore accountStore = mapping.getAccountStore();
+                final AccountStore accountStore = mapping.getAccountStore();
 
-            accountStore.accept(visitor);
+                accountStore.accept(visitor);
+            }
         }
 
         return visitor.getAccountStores();

--- a/impl/src/main/java/com/stormpath/sdk/impl/directory/DefaultOktaPasswordPolicy.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/directory/DefaultOktaPasswordPolicy.java
@@ -1,0 +1,117 @@
+package com.stormpath.sdk.impl.directory;
+
+import com.stormpath.sdk.directory.OktaPasswordPolicy;
+import com.stormpath.sdk.impl.ds.InternalDataStore;
+import com.stormpath.sdk.impl.resource.AbstractInstanceResource;
+import com.stormpath.sdk.impl.resource.BooleanProperty;
+import com.stormpath.sdk.impl.resource.DateProperty;
+import com.stormpath.sdk.impl.resource.IntegerProperty;
+import com.stormpath.sdk.impl.resource.MapProperty;
+import com.stormpath.sdk.impl.resource.Property;
+import com.stormpath.sdk.impl.resource.StringProperty;
+
+import java.util.Date;
+import java.util.Map;
+
+public class DefaultOktaPasswordPolicy extends AbstractInstanceResource implements OktaPasswordPolicy {
+
+    // SIMPLE PROPERTIES
+    static final StringProperty TYPE = new StringProperty("type");
+    static final StringProperty ID = new StringProperty("id");
+    static final StringProperty STATUS = new StringProperty("status");
+    static final StringProperty NAME = new StringProperty("name");
+    static final StringProperty DESCRIPTION = new StringProperty("description");
+    static final IntegerProperty PRIORITY = new IntegerProperty("priority");
+    static final BooleanProperty SYSTEM = new BooleanProperty("system");
+    static final DateProperty CREATED = new DateProperty("created");
+    static final DateProperty LAST_UPDATED = new DateProperty("lastUpdated");
+
+    // MAP Properties
+    static final MapProperty CONDITIONS = new MapProperty("conditions");
+    static final MapProperty SETTINGS = new MapProperty("settings");
+    static final MapProperty DELEGATION = new MapProperty("delegation");
+    static final MapProperty RULES = new MapProperty("rules");
+
+    private static final Map<String, Property> PROPERTY_DESCRIPTORS = createPropertyDescriptorMap(
+        TYPE, ID, STATUS, NAME, DESCRIPTION, PRIORITY, SYSTEM, CREATED, LAST_UPDATED, CONDITIONS, SETTINGS, DELEGATION, RULES
+    );
+
+    public DefaultOktaPasswordPolicy(InternalDataStore dataStore) {
+        super(dataStore);
+    }
+
+    public DefaultOktaPasswordPolicy(InternalDataStore dataStore, Map<String, Object> properties) {
+        super(dataStore, properties);
+    }
+
+    @Override
+    public Map<String, Property> getPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
+
+    @Override
+    public String getType() {
+        return getString(TYPE);
+    }
+
+    @Override
+    public String getId() {
+        return getString(ID);
+    }
+
+    @Override
+    public String getStatus() {
+        return getString(STATUS);
+    }
+
+    @Override
+    public String getName() {
+        return getString(NAME);
+    }
+
+    @Override
+    public String getDescription() {
+        return getString(DESCRIPTION);
+    }
+
+    @Override
+    public int getPriority() {
+        return getInt(PRIORITY);
+    }
+
+    @Override
+    public boolean getSystem() {
+        return getBoolean(SYSTEM);
+    }
+
+    @Override
+    public Map<String, Object> getConditions() {
+        return getMap(CONDITIONS);
+    }
+
+    @Override
+    public Date getCreated() {
+        return getDateProperty(CREATED);
+    }
+
+    @Override
+    public Date getLastUpdated() {
+        return getDateProperty(LAST_UPDATED);
+    }
+
+    @Override
+    public Map<String, Object> getSettings() {
+        return getMap(SETTINGS);
+    }
+
+    @Override
+    public Map<String, Object> getDelegation() {
+        return getMap(DELEGATION);
+    }
+
+    @Override
+    public Map<String, Object> getRules() {
+        return getMap(RULES);
+    }
+}

--- a/impl/src/main/java/com/stormpath/sdk/impl/directory/DefaultOktaPasswordPolicyList.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/directory/DefaultOktaPasswordPolicyList.java
@@ -1,0 +1,39 @@
+package com.stormpath.sdk.impl.directory;
+
+import com.stormpath.sdk.directory.OktaPasswordPolicy;
+import com.stormpath.sdk.directory.OktaPasswordPolicyList;
+import com.stormpath.sdk.impl.ds.InternalDataStore;
+import com.stormpath.sdk.impl.resource.AbstractCollectionResource;
+import com.stormpath.sdk.impl.resource.ArrayProperty;
+import com.stormpath.sdk.impl.resource.Property;
+
+import java.util.Map;
+
+public class DefaultOktaPasswordPolicyList extends AbstractCollectionResource<OktaPasswordPolicy> implements OktaPasswordPolicyList {
+
+    private static final ArrayProperty<OktaPasswordPolicy> ITEMS = new ArrayProperty<>("items", OktaPasswordPolicy.class);
+
+    private static final Map<String, Property> PROPERTY_DESCRIPTORS = createPropertyDescriptorMap(OFFSET, LIMIT, ITEMS);
+
+    public DefaultOktaPasswordPolicyList(InternalDataStore dataStore) {
+        super(dataStore);
+    }
+
+    public DefaultOktaPasswordPolicyList(InternalDataStore dataStore, Map<String, Object> properties) {
+        super(dataStore, properties);
+    }
+
+    public DefaultOktaPasswordPolicyList(InternalDataStore dataStore, Map<String, Object> properties, Map<String, Object> queryParams) {
+        super(dataStore, properties, queryParams);
+    }
+
+    @Override
+    public Map<String, Property> getPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    protected Class<OktaPasswordPolicy> getItemType() {
+        return OktaPasswordPolicy.class;
+    }
+}

--- a/impl/src/main/java/com/stormpath/sdk/impl/directory/OktaDirectory.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/directory/OktaDirectory.java
@@ -246,6 +246,7 @@ public class OktaDirectory extends AbstractResource implements Directory {
 
     @SuppressWarnings("unchecked")
     private PasswordPolicy transformOktaPasswordPolicy(OktaPasswordPolicy oktaPasswordPolicy) {
+        // ref: http://developer.okta.com/docs/api/resources/policy.html#GroupPasswordPolicy
         final Map<String, Object> strengthMap = (Map<String, Object>)
             ((Map<String, Object>)oktaPasswordPolicy.getSettings().get("password")).get("complexity");
         PasswordPolicy ret = new PasswordPolicy() {

--- a/impl/src/main/java/com/stormpath/sdk/impl/error/OktaError.java
+++ b/impl/src/main/java/com/stormpath/sdk/impl/error/OktaError.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stormpath.sdk.impl.error;
+
+import com.stormpath.sdk.error.Error;
+import com.stormpath.sdk.impl.resource.AbstractResource;
+import com.stormpath.sdk.impl.resource.IntegerProperty;
+import com.stormpath.sdk.impl.resource.ListProperty;
+import com.stormpath.sdk.impl.resource.Property;
+import com.stormpath.sdk.impl.resource.StringProperty;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @since 0.1
+ */
+public class OktaError extends AbstractResource implements Error, Serializable {
+
+    static final long serialVersionUID = 42L;
+
+    public static final IntegerProperty STATUS = new IntegerProperty("status");
+    static final StringProperty ERROR_CODE = new StringProperty("errorCode");
+    static final StringProperty ERROR_SUMMARY = new StringProperty("errorSummary");
+    static final ListProperty ERROR_CAUSES = new ListProperty("errorCauses");
+    static final StringProperty ERROR_ID = new StringProperty("errorId");
+
+    private static final Map<String, Property> PROPERTY_DESCRIPTORS = createPropertyDescriptorMap(
+        STATUS, ERROR_CODE, ERROR_SUMMARY, ERROR_CAUSES, ERROR_ID
+    );
+
+    public OktaError(Map<String, Object> body) {
+        super(null, body);
+    }
+
+    // Needed for this class to be serializable
+    public OktaError() {
+        super(null, null);
+    }
+
+    @Override
+    public Map<String, Property> getPropertyDescriptors() {
+        return PROPERTY_DESCRIPTORS;
+    }
+
+    @Override
+    public int getStatus() {
+        return getInt(STATUS);
+    }
+
+    @Override
+    public int getCode() {
+        return 0;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public String getMessage() {
+        List causes = getListProperty(ERROR_CAUSES.getName());
+        return ((Map<String, String>)causes.get(0)).get("errorSummary");
+    }
+
+    @Override
+    public String getDeveloperMessage() {
+        return "";
+    }
+
+    @Override
+    public String getMoreInfo() {
+        return getString(ERROR_SUMMARY);
+    }
+
+    @Override
+    public String getRequestId() {
+       return getString(ERROR_ID);
+    }
+
+}


### PR DESCRIPTION
UAT: `RegisterIT` of the TCK should pass fully

This PR builds in the ability to fetch the password policy from Okta.

It also has some foundational updates that should benefit other efforts, including:

* handling JSON List responses (by wrapping them in a Map)
* handling Okta error responses